### PR TITLE
[WHD-99] Feat: Club register api

### DIFF
--- a/src/main/java/woohakdong/server/api/controller/club/ClubController.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubController.java
@@ -1,5 +1,6 @@
 package woohakdong.server.api.controller.club;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,10 +14,14 @@ import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
 import woohakdong.server.api.controller.club.dto.ClubCreateResponse;
 import woohakdong.server.api.controller.club.dto.ClubInfoResponse;
 import woohakdong.server.api.controller.club.dto.ClubJoinGatheringInfoResponse;
+import woohakdong.server.api.service.club.ClubService;
 
 @RestController
 @RequestMapping("/v1/clubs")
+@RequiredArgsConstructor
 public class ClubController implements ClubControllerDocs {
+
+    private final ClubService clubService;
 
     @PostMapping("/validate")
     public void validateClubName(String clubName) {
@@ -25,7 +30,7 @@ public class ClubController implements ClubControllerDocs {
 
     @PostMapping
     public ClubCreateResponse createClub(ClubCreateRequest clubCreateRequest) {
-        return null;
+        return clubService.registerClub(clubCreateRequest);
     }
 
     @GetMapping("/{clubId}")

--- a/src/main/java/woohakdong/server/api/controller/club/ClubController.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubController.java
@@ -14,6 +14,7 @@ import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
 import woohakdong.server.api.controller.club.dto.ClubCreateResponse;
 import woohakdong.server.api.controller.club.dto.ClubInfoResponse;
 import woohakdong.server.api.controller.club.dto.ClubJoinGatheringInfoResponse;
+import woohakdong.server.api.controller.club.dto.ClubNameValidateRequest;
 import woohakdong.server.api.service.bank.BankService;
 import woohakdong.server.api.service.club.ClubService;
 
@@ -26,13 +27,13 @@ public class ClubController implements ClubControllerDocs {
     private final BankService bankService;
 
     @PostMapping("/validate")
-    public void validateClubName(String clubName) {
-
+    public void validateClubName(ClubNameValidateRequest request) {
+        clubService.validateClubWithNames(request.clubName(), request.clubEnglishName());
     }
 
     @PostMapping
-    public ClubCreateResponse createClub(ClubCreateRequest clubCreateRequest) {
-        return clubService.registerClub(clubCreateRequest);
+    public ClubCreateResponse createClub(ClubCreateRequest request) {
+        return clubService.registerClub(request);
     }
 
     @GetMapping("/{clubId}")
@@ -41,18 +42,18 @@ public class ClubController implements ClubControllerDocs {
     }
 
     @PutMapping("/{clubId}")
-    public ClubInfoResponse updateClubInfo(@PathVariable Long clubId, ClubCreateRequest clubCreateRequest) {
+    public ClubInfoResponse updateClubInfo(@PathVariable Long clubId, ClubCreateRequest request) {
         return null;
     }
 
     @PostMapping("/{clubId}/accounts")
-    public void registerClubAccount(@PathVariable Long clubId, ClubAccountRegisterRequest clubAccountRegisterRequest) {
-        clubService.registerClubAccount(clubId, clubAccountRegisterRequest);
+    public void registerClubAccount(@PathVariable Long clubId, ClubAccountRegisterRequest request) {
+        clubService.registerClubAccount(clubId, request);
     }
 
     @PostMapping("/accounts/validate")
-    public ClubAccountValidateResponse validateClubAccount(ClubAccountValidateRequest clubAccountValidateRequest) {
-        return bankService.certifyAccount(clubAccountValidateRequest);
+    public ClubAccountValidateResponse validateClubAccount(ClubAccountValidateRequest request) {
+        return bankService.certifyAccount(request);
     }
 
     @GetMapping("/{clubId}/join")

--- a/src/main/java/woohakdong/server/api/controller/club/ClubController.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubController.java
@@ -46,8 +46,8 @@ public class ClubController implements ClubControllerDocs {
     }
 
     @PostMapping("/{clubId}/accounts")
-    public ClubInfoResponse registerClubAccount(@PathVariable Long clubId, ClubAccountRegisterRequest clubAccountRegisterRequest) {
-        return null;
+    public void registerClubAccount(@PathVariable Long clubId, ClubAccountRegisterRequest clubAccountRegisterRequest) {
+        clubService.registerClubAccount(clubId, clubAccountRegisterRequest);
     }
 
     @PostMapping("/accounts/validate")

--- a/src/main/java/woohakdong/server/api/controller/club/ClubController.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubController.java
@@ -14,6 +14,7 @@ import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
 import woohakdong.server.api.controller.club.dto.ClubCreateResponse;
 import woohakdong.server.api.controller.club.dto.ClubInfoResponse;
 import woohakdong.server.api.controller.club.dto.ClubJoinGatheringInfoResponse;
+import woohakdong.server.api.service.bank.BankService;
 import woohakdong.server.api.service.club.ClubService;
 
 @RestController
@@ -22,6 +23,7 @@ import woohakdong.server.api.service.club.ClubService;
 public class ClubController implements ClubControllerDocs {
 
     private final ClubService clubService;
+    private final BankService bankService;
 
     @PostMapping("/validate")
     public void validateClubName(String clubName) {
@@ -50,7 +52,7 @@ public class ClubController implements ClubControllerDocs {
 
     @PostMapping("/accounts/validate")
     public ClubAccountValidateResponse validateClubAccount(ClubAccountValidateRequest clubAccountValidateRequest) {
-        return null;
+        return bankService.certifyAccount(clubAccountValidateRequest);
     }
 
     @GetMapping("/{clubId}/join")

--- a/src/main/java/woohakdong/server/api/controller/club/ClubController.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubController.java
@@ -1,0 +1,55 @@
+package woohakdong.server.api.controller.club;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import woohakdong.server.api.controller.club.dto.ClubAccountRegisterRequest;
+import woohakdong.server.api.controller.club.dto.ClubAccountValidateRequest;
+import woohakdong.server.api.controller.club.dto.ClubAccountValidateResponse;
+import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
+import woohakdong.server.api.controller.club.dto.ClubCreateResponse;
+import woohakdong.server.api.controller.club.dto.ClubInfoResponse;
+import woohakdong.server.api.controller.club.dto.ClubJoinGatheringInfoResponse;
+
+@RestController
+@RequestMapping("/v1/clubs")
+public class ClubController implements ClubControllerDocs {
+
+    @PostMapping("/validate")
+    public void validateClubName(String clubName) {
+
+    }
+
+    @PostMapping
+    public ClubCreateResponse createClub(ClubCreateRequest clubCreateRequest) {
+        return null;
+    }
+
+    @GetMapping("/{clubId}")
+    public ClubInfoResponse getClubInfo(@PathVariable Long clubId) {
+        return null;
+    }
+
+    @PutMapping("/{clubId}")
+    public ClubInfoResponse updateClubInfo(@PathVariable Long clubId, ClubCreateRequest clubCreateRequest) {
+        return null;
+    }
+
+    @PostMapping("/{clubId}/accounts")
+    public ClubInfoResponse registerClubAccount(@PathVariable Long clubId, ClubAccountRegisterRequest clubAccountRegisterRequest) {
+        return null;
+    }
+
+    @PostMapping("/accounts/validate")
+    public ClubAccountValidateResponse validateClubAccount(ClubAccountValidateRequest clubAccountValidateRequest) {
+        return null;
+    }
+
+    @GetMapping("/{clubId}/join")
+    public ClubJoinGatheringInfoResponse getClubJoinInfo(@PathVariable Long clubId) {
+        return null;
+    }
+}

--- a/src/main/java/woohakdong/server/api/controller/club/ClubControllerDocs.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubControllerDocs.java
@@ -1,0 +1,55 @@
+package woohakdong.server.api.controller.club;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import woohakdong.server.api.controller.club.dto.ClubAccountRegisterRequest;
+import woohakdong.server.api.controller.club.dto.ClubAccountValidateRequest;
+import woohakdong.server.api.controller.club.dto.ClubAccountValidateResponse;
+import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
+import woohakdong.server.api.controller.club.dto.ClubCreateResponse;
+import woohakdong.server.api.controller.club.dto.ClubInfoResponse;
+import woohakdong.server.api.controller.club.dto.ClubJoinGatheringInfoResponse;
+
+@Tag(name = "Club", description = "동아리 관련 API")
+public interface ClubControllerDocs {
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "동아리 이름 유효성 검증", description = "동아리 이름을 입력하면, 해당 이름이 유효한지 검증합니다.")
+    @ApiResponse(responseCode = "200", description = "동아리 이름 유효성 검증 성공", useReturnTypeSchema = true)
+    @ApiResponse(responseCode = "400", description = "동아리 이름 유효성 검증 실패")
+    public void validateClubName(String clubName);
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "동아리를 등록", description = "등록할 동아리 정보를 제공하면, 동아리 등록 후 동아리 id를 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "동아리 등록 성공", useReturnTypeSchema = true)
+    public ClubCreateResponse createClub(ClubCreateRequest clubCreateRequest);
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "동아리 정보 불러오기", description = "동아리 id를 입력하면, 해당 동아리의 정보를 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "동아리 정보 조회 성공", useReturnTypeSchema = true)
+    public ClubInfoResponse getClubInfo(Long clubId);
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "동아리 정보 수정", description = "수정할 동아리 정보를 제공하면, 해당 동아리의 정보를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "동아리 정보 수정 성공", useReturnTypeSchema = true)
+    public ClubInfoResponse updateClubInfo(Long clubId, ClubCreateRequest clubCreateRequest);
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "동아리 계좌 등록", description = "동아리에서 사용하는 계좌 정보를 등록합니다.")
+    @ApiResponse(responseCode = "200", description = "동아리 계좌 등록 성공", useReturnTypeSchema = true)
+    public ClubInfoResponse registerClubAccount(Long clubId, ClubAccountRegisterRequest clubAccountRegisterRequest);
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "동아리 계좌 유효성 검증", description = "동아리에서 사용하는 계좌 정보를 입력하면, 해당 계좌 정보가 유효한지 검증합니다.")
+    @ApiResponse(responseCode = "200", description = "동아리 계좌 유효성 검증 성공", useReturnTypeSchema = true)
+    public ClubAccountValidateResponse validateClubAccount(ClubAccountValidateRequest clubAccountValidateRequest);
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "동아리 가입 요청을 위한 정보 불러오기", description = "동아리원들에게 제공할 링크 및 정보를 제공합니다.")
+    @ApiResponse(responseCode = "200", description = "동아리 가입 요청을 위한 정보 불러오기 성공", useReturnTypeSchema = true)
+    public ClubJoinGatheringInfoResponse getClubJoinInfo(Long clubId);
+
+
+}

--- a/src/main/java/woohakdong/server/api/controller/club/ClubControllerDocs.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubControllerDocs.java
@@ -11,6 +11,7 @@ import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
 import woohakdong.server.api.controller.club.dto.ClubCreateResponse;
 import woohakdong.server.api.controller.club.dto.ClubInfoResponse;
 import woohakdong.server.api.controller.club.dto.ClubJoinGatheringInfoResponse;
+import woohakdong.server.api.controller.club.dto.ClubNameValidateRequest;
 
 @Tag(name = "Club", description = "동아리 관련 API")
 public interface ClubControllerDocs {
@@ -19,7 +20,7 @@ public interface ClubControllerDocs {
     @Operation(summary = "동아리 이름 유효성 검증", description = "동아리 이름을 입력하면, 해당 이름이 유효한지 검증합니다.")
     @ApiResponse(responseCode = "200", description = "동아리 이름 유효성 검증 성공", useReturnTypeSchema = true)
     @ApiResponse(responseCode = "400", description = "동아리 이름 유효성 검증 실패")
-    public void validateClubName(String clubName);
+    public void validateClubName(ClubNameValidateRequest clubNameValidateRequest);
 
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "동아리를 등록", description = "등록할 동아리 정보를 제공하면, 동아리 등록 후 동아리 id를 반환합니다.")
@@ -27,12 +28,12 @@ public interface ClubControllerDocs {
     public ClubCreateResponse createClub(ClubCreateRequest clubCreateRequest);
 
     @SecurityRequirement(name = "accessToken")
-    @Operation(summary = "동아리 정보 불러오기", description = "동아리 id를 입력하면, 해당 동아리의 정보를 반환합니다.")
+    @Operation(summary = "동아리 정보 불러오기 (진행 중)", description = "동아리 id를 입력하면, 해당 동아리의 정보를 반환합니다.")
     @ApiResponse(responseCode = "200", description = "동아리 정보 조회 성공", useReturnTypeSchema = true)
     public ClubInfoResponse getClubInfo(Long clubId);
 
     @SecurityRequirement(name = "accessToken")
-    @Operation(summary = "동아리 정보 수정", description = "수정할 동아리 정보를 제공하면, 해당 동아리의 정보를 수정합니다.")
+    @Operation(summary = "동아리 정보 수정 (진행 중)", description = "수정할 동아리 정보를 제공하면, 해당 동아리의 정보를 수정합니다.")
     @ApiResponse(responseCode = "200", description = "동아리 정보 수정 성공", useReturnTypeSchema = true)
     public ClubInfoResponse updateClubInfo(Long clubId, ClubCreateRequest clubCreateRequest);
 
@@ -47,7 +48,7 @@ public interface ClubControllerDocs {
     public ClubAccountValidateResponse validateClubAccount(ClubAccountValidateRequest clubAccountValidateRequest);
 
     @SecurityRequirement(name = "accessToken")
-    @Operation(summary = "동아리 가입 요청을 위한 정보 불러오기", description = "동아리원들에게 제공할 링크 및 정보를 제공합니다.")
+    @Operation(summary = "동아리 가입 요청을 위한 정보 불러오기 (진행 중)", description = "동아리원들에게 제공할 링크 및 정보를 제공합니다.")
     @ApiResponse(responseCode = "200", description = "동아리 가입 요청을 위한 정보 불러오기 성공", useReturnTypeSchema = true)
     public ClubJoinGatheringInfoResponse getClubJoinInfo(Long clubId);
 

--- a/src/main/java/woohakdong/server/api/controller/club/ClubControllerDocs.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubControllerDocs.java
@@ -39,7 +39,7 @@ public interface ClubControllerDocs {
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "동아리 계좌 등록", description = "동아리에서 사용하는 계좌 정보를 등록합니다.")
     @ApiResponse(responseCode = "200", description = "동아리 계좌 등록 성공", useReturnTypeSchema = true)
-    public ClubInfoResponse registerClubAccount(Long clubId, ClubAccountRegisterRequest clubAccountRegisterRequest);
+    public void registerClubAccount(Long clubId, ClubAccountRegisterRequest clubAccountRegisterRequest);
 
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "동아리 계좌 유효성 검증", description = "동아리에서 사용하는 계좌 정보를 입력하면, 해당 계좌 정보가 유효한지 검증합니다.")

--- a/src/main/java/woohakdong/server/api/controller/club/dto/ClubAccountRegisterRequest.java
+++ b/src/main/java/woohakdong/server/api/controller/club/dto/ClubAccountRegisterRequest.java
@@ -1,7 +1,11 @@
 package woohakdong.server.api.controller.club.dto;
 
+import lombok.Builder;
+
+@Builder
 public record ClubAccountRegisterRequest(
-        String accountName,
-        String accountNumber
+        String clubAccountBankName,
+        String clubAccountNumber,
+        String clubAccountPinTechNumber
 ) {
 }

--- a/src/main/java/woohakdong/server/api/controller/club/dto/ClubAccountRegisterRequest.java
+++ b/src/main/java/woohakdong/server/api/controller/club/dto/ClubAccountRegisterRequest.java
@@ -1,0 +1,7 @@
+package woohakdong.server.api.controller.club.dto;
+
+public record ClubAccountRegisterRequest(
+        String accountName,
+        String accountNumber
+) {
+}

--- a/src/main/java/woohakdong/server/api/controller/club/dto/ClubAccountValidateRequest.java
+++ b/src/main/java/woohakdong/server/api/controller/club/dto/ClubAccountValidateRequest.java
@@ -1,0 +1,12 @@
+package woohakdong.server.api.controller.club.dto;
+
+import lombok.NonNull;
+
+public record ClubAccountValidateRequest(
+        @NonNull
+        String clubAccountBankName,
+
+        @NonNull
+        String clubAccountNumber
+) {
+}

--- a/src/main/java/woohakdong/server/api/controller/club/dto/ClubAccountValidateRequest.java
+++ b/src/main/java/woohakdong/server/api/controller/club/dto/ClubAccountValidateRequest.java
@@ -1,7 +1,9 @@
 package woohakdong.server.api.controller.club.dto;
 
+import lombok.Builder;
 import lombok.NonNull;
 
+@Builder
 public record ClubAccountValidateRequest(
         @NonNull
         String clubAccountBankName,

--- a/src/main/java/woohakdong/server/api/controller/club/dto/ClubAccountValidateResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/club/dto/ClubAccountValidateResponse.java
@@ -1,6 +1,11 @@
 package woohakdong.server.api.controller.club.dto;
 
+import lombok.Builder;
+
+@Builder
 public record ClubAccountValidateResponse(
+        String clubAccountBankName,
+        String clubAccountNumber,
         String clubAccountPinTechNumber
 ) {
 }

--- a/src/main/java/woohakdong/server/api/controller/club/dto/ClubAccountValidateResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/club/dto/ClubAccountValidateResponse.java
@@ -1,0 +1,6 @@
+package woohakdong.server.api.controller.club.dto;
+
+public record ClubAccountValidateResponse(
+        String clubAccountPinTechNumber
+) {
+}

--- a/src/main/java/woohakdong/server/api/controller/club/dto/ClubCreateRequest.java
+++ b/src/main/java/woohakdong/server/api/controller/club/dto/ClubCreateRequest.java
@@ -1,0 +1,22 @@
+package woohakdong.server.api.controller.club.dto;
+
+import lombok.Builder;
+import lombok.NonNull;
+import woohakdong.server.domain.club.Club;
+
+@Builder
+public record ClubCreateRequest(
+        @NonNull
+        String clubName,
+
+        @NonNull
+        String clubEnglishName,
+
+        String clubImage,
+        String clubDescription,
+        String clubRoom,
+
+        String clubGeneration,
+        int clubDues
+){
+}

--- a/src/main/java/woohakdong/server/api/controller/club/dto/ClubCreateResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/club/dto/ClubCreateResponse.java
@@ -1,0 +1,9 @@
+package woohakdong.server.api.controller.club.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ClubCreateResponse(
+        Long clubId
+) {
+}

--- a/src/main/java/woohakdong/server/api/controller/club/dto/ClubInfoResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/club/dto/ClubInfoResponse.java
@@ -1,0 +1,12 @@
+package woohakdong.server.api.controller.club.dto;
+
+public record ClubInfoResponse(
+        Long clubId,
+        String clubName,
+        String clubNameEnglish,
+        String clubImage,
+        String clubDescription,
+        String clubRoom,
+        String clubGeneration
+) {
+}

--- a/src/main/java/woohakdong/server/api/controller/club/dto/ClubJoinGatheringInfoResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/club/dto/ClubJoinGatheringInfoResponse.java
@@ -1,0 +1,13 @@
+package woohakdong.server.api.controller.club.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ClubJoinGatheringInfoResponse(
+        int gatheringId,
+        String gatheringName,
+        String gatheringLink,
+        String gatheringDescription,
+        int gatheringAmount
+) {
+}

--- a/src/main/java/woohakdong/server/api/controller/club/dto/ClubNameValidateRequest.java
+++ b/src/main/java/woohakdong/server/api/controller/club/dto/ClubNameValidateRequest.java
@@ -1,0 +1,12 @@
+package woohakdong.server.api.controller.club.dto;
+
+import lombok.NonNull;
+
+public record ClubNameValidateRequest(
+        @NonNull
+        String clubName,
+
+        @NonNull
+        String clubEnglishName
+) {
+}

--- a/src/main/java/woohakdong/server/api/service/bank/BankService.java
+++ b/src/main/java/woohakdong/server/api/service/bank/BankService.java
@@ -1,0 +1,8 @@
+package woohakdong.server.api.service.bank;
+
+import woohakdong.server.api.controller.club.dto.ClubAccountValidateRequest;
+import woohakdong.server.api.controller.club.dto.ClubAccountValidateResponse;
+
+public interface BankService {
+    ClubAccountValidateResponse certifyAccount(ClubAccountValidateRequest clubAccountValidateRequest);
+}

--- a/src/main/java/woohakdong/server/api/service/bank/MockBankService.java
+++ b/src/main/java/woohakdong/server/api/service/bank/MockBankService.java
@@ -1,0 +1,50 @@
+package woohakdong.server.api.service.bank;
+
+import static woohakdong.server.common.exception.CustomErrorInfo.BANK_INVALID_ACCOUNT_NUMBER;
+import static woohakdong.server.common.exception.CustomErrorInfo.BANK_NOT_SUPPORTED;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import woohakdong.server.api.controller.club.dto.ClubAccountValidateRequest;
+import woohakdong.server.api.controller.club.dto.ClubAccountValidateResponse;
+import woohakdong.server.common.exception.CustomException;
+
+@Service
+public class MockBankService implements BankService {
+
+    private final static Map<String, Map<String, String>> certifiedBanks = new HashMap<>();
+
+    static {
+        Map<String, String> kbBank = new HashMap<>();
+        kbBank.put("1234567890", "PIN-1234567890"); // 계좌번호, PIN
+        kbBank.put("1111111111", "PIN-1111111111");
+
+        Map<String, String> shinhanBank = new HashMap<>();
+        shinhanBank.put("2222222222", "PIN-2222222222");
+        shinhanBank.put("3333333333", "PIN-3333333333");
+
+        certifiedBanks.put("국민은행", kbBank);
+        certifiedBanks.put("신한은행", shinhanBank);
+    }
+
+    public ClubAccountValidateResponse certifyAccount(ClubAccountValidateRequest clubAccountValidateRequest) {
+        String clubAccountBankName = clubAccountValidateRequest.clubAccountBankName();
+        String clubAccountNumber = clubAccountValidateRequest.clubAccountNumber();
+
+        if (!certifiedBanks.containsKey(clubAccountBankName)) {
+            throw new CustomException(BANK_NOT_SUPPORTED);
+        }
+
+        Map<String, String> bank = certifiedBanks.get(clubAccountBankName);
+        if (!bank.containsKey(clubAccountNumber)) {
+            throw new CustomException(BANK_INVALID_ACCOUNT_NUMBER);
+        }
+
+        return ClubAccountValidateResponse.builder()
+                .clubAccountBankName(clubAccountBankName)
+                .clubAccountNumber(clubAccountNumber)
+                .clubAccountPinTechNumber(bank.get(clubAccountNumber))
+                .build();
+    }
+}

--- a/src/main/java/woohakdong/server/api/service/club/ClubService.java
+++ b/src/main/java/woohakdong/server/api/service/club/ClubService.java
@@ -1,21 +1,31 @@
 package woohakdong.server.api.service.club;
 
+import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_MEMBER_ROLE_NOT_ALLOWED;
 import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_NAME_DUPLICATION;
+import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_NOT_FOUND;
 import static woohakdong.server.common.exception.CustomErrorInfo.MEMBER_NOT_FOUND;
 import static woohakdong.server.common.exception.CustomErrorInfo.SCHOOL_NOT_FOUND;
+import static woohakdong.server.domain.clubmember.ClubMemberRole.PRESIDENT;
 import static woohakdong.server.domain.gathering.GatheringType.JOIN;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import woohakdong.server.api.controller.club.dto.ClubAccountRegisterRequest;
 import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
 import woohakdong.server.api.controller.club.dto.ClubCreateResponse;
 import woohakdong.server.common.exception.CustomException;
 import woohakdong.server.common.security.jwt.CustomUserDetails;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
+import woohakdong.server.domain.clubAccount.ClubAccount;
+import woohakdong.server.domain.clubAccount.ClubAccountRepository;
+import woohakdong.server.domain.clubmember.ClubMember;
+import woohakdong.server.domain.clubmember.ClubMemberRepository;
+import woohakdong.server.domain.clubmember.ClubMemberRole;
 import woohakdong.server.domain.gathering.Gathering;
 import woohakdong.server.domain.member.Member;
 import woohakdong.server.domain.member.MemberRepository;
@@ -30,6 +40,8 @@ public class ClubService {
     private final ClubRepository clubRepository;
     private final MemberRepository memberRepository;
     private final SchoolRepository schoolRepository;
+    private final ClubAccountRepository clubAccountRepository;
+    private final ClubMemberRepository clubMemberRepository;
 
     public void validateClubWithNames(String clubName, String clubEnglishName) {
         if (clubRepository.existsByClubNameOrClubEnglishName(clubName, clubEnglishName)) {
@@ -45,11 +57,29 @@ public class ClubService {
 
         Club club = createClub(clubCreateRequest, school);
         club.addGathering(createJoinGathering(clubCreateRequest, club));
+
+        ClubMember clubMember = createClubMember(member, club, PRESIDENT);
+        club.addClubMember(clubMember);
+
         clubRepository.save(club);
 
         return ClubCreateResponse.builder()
                 .clubId(club.getClubId())
                 .build();
+    }
+
+    @Transactional
+    public void registerClubAccount(Long clubId, ClubAccountRegisterRequest clubAccountRegisterRequest) {
+        Member member = getMemberFromJwtInformation();
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new CustomException(CLUB_NOT_FOUND));
+
+        if ( !clubMemberRepository.existsByClubAndMemberAndClubMemberRole(club, member, PRESIDENT) ) {
+            throw new CustomException(CLUB_MEMBER_ROLE_NOT_ALLOWED);
+        }
+
+        ClubAccount clubAccount = createClubAccount(clubAccountRegisterRequest, club);
+        clubAccountRepository.save(clubAccount);
     }
 
     private Club createClub(ClubCreateRequest clubCreateRequest, School school) {
@@ -81,5 +111,30 @@ public class ClubService {
 
         return memberRepository.findByMemberProvideId(provideId)
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+    }
+
+    private ClubAccount createClubAccount(ClubAccountRegisterRequest clubAccountRegisterRequest, Club club) {
+        return ClubAccount.builder()
+                .clubAccountBankName(clubAccountRegisterRequest.clubAccountBankName())
+                .clubAccountNumber(clubAccountRegisterRequest.clubAccountNumber())
+                .clubAccountPinTechNumber(clubAccountRegisterRequest.clubAccountPinTechNumber())
+                .club(club)
+                .build();
+    }
+
+    private ClubMember createClubMember(Member member, Club club, ClubMemberRole role) {
+        return ClubMember.builder()
+                .clubMemberRole(role)
+                .member(member)
+                .club(club)
+                .clubMemberAssignedTerm(getAssignedTerm())
+                .build();
+    }
+
+    private LocalDate getAssignedTerm() {
+        LocalDate now = LocalDate.now();
+        int year = now.getYear();
+        int semester = now.getMonthValue() <= 6 ? 1 : 7; // 1: 1학기, 7: 2학기
+        return LocalDate.of(year, semester, 1);
     }
 }

--- a/src/main/java/woohakdong/server/api/service/club/ClubService.java
+++ b/src/main/java/woohakdong/server/api/service/club/ClubService.java
@@ -1,0 +1,85 @@
+package woohakdong.server.api.service.club;
+
+import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_NAME_DUPLICATION;
+import static woohakdong.server.common.exception.CustomErrorInfo.MEMBER_NOT_FOUND;
+import static woohakdong.server.common.exception.CustomErrorInfo.SCHOOL_NOT_FOUND;
+import static woohakdong.server.domain.gathering.GatheringType.JOIN;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
+import woohakdong.server.api.controller.club.dto.ClubCreateResponse;
+import woohakdong.server.common.exception.CustomException;
+import woohakdong.server.common.security.jwt.CustomUserDetails;
+import woohakdong.server.domain.club.Club;
+import woohakdong.server.domain.club.ClubRepository;
+import woohakdong.server.domain.gathering.Gathering;
+import woohakdong.server.domain.member.Member;
+import woohakdong.server.domain.member.MemberRepository;
+import woohakdong.server.domain.school.School;
+import woohakdong.server.domain.school.SchoolRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ClubService {
+
+    private final ClubRepository clubRepository;
+    private final MemberRepository memberRepository;
+    private final SchoolRepository schoolRepository;
+
+    public void validateClubWithNames(String clubName, String clubEnglishName) {
+        if (clubRepository.existsByClubNameOrClubEnglishName(clubName, clubEnglishName)) {
+            throw new CustomException(CLUB_NAME_DUPLICATION);
+        }
+    }
+
+    @Transactional
+    public ClubCreateResponse registerClub(ClubCreateRequest clubCreateRequest) {
+        Member member = getMemberFromJwtInformation();
+        School school = schoolRepository.findById(member.getSchool().getSchoolId())
+                .orElseThrow(() -> new CustomException(SCHOOL_NOT_FOUND));
+
+        Club club = createClub(clubCreateRequest, school);
+        club.addGathering(createJoinGathering(clubCreateRequest, club));
+        clubRepository.save(club);
+
+        return ClubCreateResponse.builder()
+                .clubId(club.getClubId())
+                .build();
+    }
+
+    private Club createClub(ClubCreateRequest clubCreateRequest, School school) {
+        validateClubWithNames(clubCreateRequest.clubName(), clubCreateRequest.clubEnglishName());
+        return Club.builder()
+                .clubName(clubCreateRequest.clubName())
+                .clubEnglishName(clubCreateRequest.clubEnglishName())
+                .clubImage(clubCreateRequest.clubImage())
+                .clubDescription(clubCreateRequest.clubDescription())
+                .clubRoom(clubCreateRequest.clubRoom())
+                .school(school)
+                .build();
+    }
+
+    private Gathering createJoinGathering(ClubCreateRequest clubCreateRequest, Club club) {
+        return Gathering.builder()
+                .gatheringLink("https://woohakdong.com/clubs/" + club.getClubEnglishName())
+                .club(club)
+                .gatheringAmount(clubCreateRequest.clubDues())
+                .gatheringType(JOIN)
+                .gatheringName(clubCreateRequest.clubGeneration() + "기 모집")
+                .build();
+    }
+
+    private Member getMemberFromJwtInformation() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        String provideId = userDetails.getUsername();
+
+        return memberRepository.findByMemberProvideId(provideId)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/woohakdong/server/common/exception/CustomErrorInfo.java
+++ b/src/main/java/woohakdong/server/common/exception/CustomErrorInfo.java
@@ -12,6 +12,7 @@ public enum CustomErrorInfo {
     REFRESH_TOKEN_ALREADY_EXISTS(400, "refresh token already exists", 400004),
     UTIL_IMAGE_COUNT_INVALID(400, "Image count should be greater than 0", 400005),
     MEMBER_NOT_FOUND(400, "member not found", 400006),
+    SCHOOL_NOT_FOUND(400, "school not found", 400007),
 
     // 401 UNAUTHORIZED
     INVALID_ACCESS_TOKEN(401, "Invaild access token", 401001),
@@ -21,6 +22,7 @@ public enum CustomErrorInfo {
     // 404 NOT_FOUND
 
     // 409 CONFLICT
+    CLUB_NAME_DUPLICATION(409, "Duplicate club name", 409001),
 
     // 500 INTERNAL_SERVER_ERROR
     INTERNAL_SERVER_ERROR(500, "Internal server error", 500001);

--- a/src/main/java/woohakdong/server/common/exception/CustomErrorInfo.java
+++ b/src/main/java/woohakdong/server/common/exception/CustomErrorInfo.java
@@ -15,6 +15,8 @@ public enum CustomErrorInfo {
     SCHOOL_NOT_FOUND(400, "school not found", 400007),
     BANK_NOT_SUPPORTED(400, "bank not supported", 400008),
     BANK_INVALID_ACCOUNT_NUMBER(400, "account number invalid", 400009),
+    CLUB_NOT_FOUND(400, "club not found", 400010),
+    CLUB_MEMBER_ROLE_NOT_ALLOWED(400, "club member role not allowed", 400011),
 
     // 401 UNAUTHORIZED
     INVALID_ACCESS_TOKEN(401, "Invaild access token", 401001),

--- a/src/main/java/woohakdong/server/common/exception/CustomErrorInfo.java
+++ b/src/main/java/woohakdong/server/common/exception/CustomErrorInfo.java
@@ -13,6 +13,8 @@ public enum CustomErrorInfo {
     UTIL_IMAGE_COUNT_INVALID(400, "Image count should be greater than 0", 400005),
     MEMBER_NOT_FOUND(400, "member not found", 400006),
     SCHOOL_NOT_FOUND(400, "school not found", 400007),
+    BANK_NOT_SUPPORTED(400, "bank not supported", 400008),
+    BANK_INVALID_ACCOUNT_NUMBER(400, "account number invalid", 400009),
 
     // 401 UNAUTHORIZED
     INVALID_ACCESS_TOKEN(401, "Invaild access token", 401001),

--- a/src/main/java/woohakdong/server/domain/club/Club.java
+++ b/src/main/java/woohakdong/server/domain/club/Club.java
@@ -1,5 +1,6 @@
 package woohakdong.server.domain.club;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -43,7 +44,7 @@ public class Club {
     @JoinColumn(name = "school_id")
     private School school;
 
-    @OneToMany(mappedBy = "club")
+    @OneToMany(mappedBy = "club", cascade = CascadeType.ALL)
     private List<Gathering> gatherings = new ArrayList<>();
 
     @Builder
@@ -56,5 +57,9 @@ public class Club {
         this.clubName = clubName;
         this.clubRoom = clubRoom;
         this.school = school;
+    }
+
+    public void addGathering(Gathering gathering) {
+        this.gatherings.add(gathering);
     }
 }

--- a/src/main/java/woohakdong/server/domain/club/Club.java
+++ b/src/main/java/woohakdong/server/domain/club/Club.java
@@ -17,6 +17,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.clubmember.ClubMember;
 import woohakdong.server.domain.gathering.Gathering;
 import woohakdong.server.domain.school.School;
 
@@ -47,6 +48,9 @@ public class Club {
     @OneToMany(mappedBy = "club", cascade = CascadeType.ALL)
     private List<Gathering> gatherings = new ArrayList<>();
 
+    @OneToMany(mappedBy = "club", cascade = CascadeType.ALL)
+    private List<ClubMember> clubMembers = new ArrayList<>();
+
     @Builder
     public Club(String clubDescription, String clubEnglishName, LocalDate clubEstablishmentDate, String clubImage,
                 String clubName, String clubRoom, School school) {
@@ -61,5 +65,9 @@ public class Club {
 
     public void addGathering(Gathering gathering) {
         this.gatherings.add(gathering);
+    }
+
+    public void addClubMember(ClubMember clubMember) {
+        this.clubMembers.add(clubMember);
     }
 }

--- a/src/main/java/woohakdong/server/domain/clubAccount/ClubAccount.java
+++ b/src/main/java/woohakdong/server/domain/clubAccount/ClubAccount.java
@@ -1,0 +1,47 @@
+package woohakdong.server.domain.clubAccount;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import woohakdong.server.domain.club.Club;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ClubAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long clubAccountId;
+
+    @Column(nullable = false)
+    private String clubAccountBankName;
+
+    @Column(nullable = false)
+    private String clubAccountNumber;
+
+    @Column(nullable = false)
+    private String clubAccountPinTechNumber;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    @Builder
+    public ClubAccount(Club club, String clubAccountBankName, String clubAccountNumber,
+                       String clubAccountPinTechNumber) {
+        this.club = club;
+        this.clubAccountBankName = clubAccountBankName;
+        this.clubAccountNumber = clubAccountNumber;
+        this.clubAccountPinTechNumber = clubAccountPinTechNumber;
+    }
+}

--- a/src/main/java/woohakdong/server/domain/clubAccount/ClubAccountRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubAccount/ClubAccountRepository.java
@@ -1,0 +1,7 @@
+package woohakdong.server.domain.clubAccount;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClubAccountRepository extends JpaRepository<ClubAccount, Long> {
+    Boolean existsByClubAccountBankNameAndClubAccountNumber(String clubAccountBankName, String clubAccountNumber);
+}

--- a/src/main/java/woohakdong/server/domain/clubAccount/ClubAccountRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubAccount/ClubAccountRepository.java
@@ -1,7 +1,11 @@
 package woohakdong.server.domain.clubAccount;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import woohakdong.server.domain.club.Club;
 
 public interface ClubAccountRepository extends JpaRepository<ClubAccount, Long> {
     Boolean existsByClubAccountBankNameAndClubAccountNumber(String clubAccountBankName, String clubAccountNumber);
+
+    Optional<ClubAccount> findByClub(Club club);
 }

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
@@ -27,7 +27,6 @@ public class ClubMember {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long clubMemberId;
 
-    @Column(nullable = false)
     private LocalDate clubJoinedDate;
 
     @Column(nullable = false)
@@ -36,6 +35,8 @@ public class ClubMember {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private ClubMemberRole clubMemberRole;
+
+    private String clubGeneration;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
@@ -1,0 +1,57 @@
+package woohakdong.server.domain.clubmember;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import woohakdong.server.domain.club.Club;
+import woohakdong.server.domain.member.Member;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ClubMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long clubMemberId;
+
+    @Column(nullable = false)
+    private LocalDate clubJoinedDate;
+
+    @Column(nullable = false)
+    private LocalDate clubMemberAssignedTerm;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ClubMemberRole clubMemberRole;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    @Builder
+    public ClubMember(Club club, LocalDate clubJoinedDate, LocalDate clubMemberAssignedTerm,
+                      ClubMemberRole clubMemberRole, Member member) {
+        this.club = club;
+        this.clubJoinedDate = clubJoinedDate;
+        this.clubMemberAssignedTerm = clubMemberAssignedTerm;
+        this.clubMemberRole = clubMemberRole;
+        this.member = member;
+    }
+}

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepository.java
@@ -1,0 +1,10 @@
+package woohakdong.server.domain.clubmember;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import woohakdong.server.domain.club.Club;
+import woohakdong.server.domain.member.Member;
+
+public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
+
+    Boolean existsByClubAndMemberAndClubMemberRole(Club club, Member member, ClubMemberRole clubMemberRole);
+}

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRole.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRole.java
@@ -1,0 +1,13 @@
+package woohakdong.server.domain.clubmember;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ClubMemberRole {
+
+    PRESIDENT("회장"),
+    OFFICER("임원"),
+    MEMBER("회원");
+
+    private final String role;
+}

--- a/src/main/java/woohakdong/server/domain/gathering/Gathering.java
+++ b/src/main/java/woohakdong/server/domain/gathering/Gathering.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +18,7 @@ import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.clubmember.ClubMember;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Gathering {
 

--- a/src/main/java/woohakdong/server/domain/gathering/Gathering.java
+++ b/src/main/java/woohakdong/server/domain/gathering/Gathering.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import woohakdong.server.domain.club.Club;
+import woohakdong.server.domain.clubmember.ClubMember;
 
 @Entity
 @NoArgsConstructor
@@ -40,6 +41,10 @@ public class Gathering {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_id")
     private Club club;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_member_id")
+    private ClubMember clubMember;
 
     @Builder
     public Gathering(String gatheringName, String gatheringDescription, int gatheringAmount, String gatheringLink,

--- a/src/test/java/woohakdong/server/api/service/bank/MockBankServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/bank/MockBankServiceTest.java
@@ -1,0 +1,63 @@
+package woohakdong.server.api.service.bank;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static woohakdong.server.common.exception.CustomErrorInfo.BANK_INVALID_ACCOUNT_NUMBER;
+import static woohakdong.server.common.exception.CustomErrorInfo.BANK_NOT_SUPPORTED;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import woohakdong.server.api.controller.club.dto.ClubAccountValidateRequest;
+import woohakdong.server.api.controller.club.dto.ClubAccountValidateResponse;
+import woohakdong.server.common.exception.CustomException;
+
+class MockBankServiceTest {
+
+    private final MockBankService mockBankService = new MockBankService();
+
+    @DisplayName("은행 이름과 계좌번호가 주어졌을 때, 해당 계좌번호의 PIN을 반환한다.")
+    @Test
+    void certifyAccount() {
+        // Given
+        ClubAccountValidateRequest accountValidateRequest = createAccountValidateRequest("국민은행", "1234567890");
+
+        // When
+        ClubAccountValidateResponse result = mockBankService.certifyAccount(accountValidateRequest);
+
+        // Then
+        assertThat(result).isNotNull()
+                .extracting("clubAccountBankName", "clubAccountNumber", "clubAccountPinTechNumber")
+                .containsExactly("국민은행", "1234567890", "PIN-1234567890");
+    }
+
+    @DisplayName("존재하지 않은 은행 이름으로 인증을 시도하면 BANK_NOT_SUPPORTED이 발생한다.")
+    @Test
+    void certifyAccountWithWrongBankName() {
+        // Given
+        ClubAccountValidateRequest accountValidateRequest = createAccountValidateRequest("우학동은행", "1234567890");
+
+        // When & Then
+        assertThatThrownBy(() -> mockBankService.certifyAccount(accountValidateRequest))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(BANK_NOT_SUPPORTED.getMessage());
+    }
+
+    @DisplayName("존재하지 않는 계좌번호로 인증을 시도하면 BANK_INVALID_ACCOUNT_NUMBER가 발생한다.")
+    @Test
+    void test() {
+        // Given
+        ClubAccountValidateRequest accountValidateRequest = createAccountValidateRequest("국민은행", "0000000000");
+
+        // When & Then
+        assertThatThrownBy(() -> mockBankService.certifyAccount(accountValidateRequest))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(BANK_INVALID_ACCOUNT_NUMBER.getMessage());
+    }
+
+    private ClubAccountValidateRequest createAccountValidateRequest(String bankName, String accountNumber) {
+        return ClubAccountValidateRequest.builder()
+                .clubAccountBankName(bankName)
+                .clubAccountNumber(accountNumber)
+                .build();
+    }
+}

--- a/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
@@ -1,0 +1,95 @@
+package woohakdong.server.api.service.club;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static woohakdong.server.domain.gathering.GatheringType.JOIN;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
+import woohakdong.server.api.controller.club.dto.ClubCreateResponse;
+import woohakdong.server.common.security.jwt.CustomUserDetails;
+import woohakdong.server.domain.club.Club;
+import woohakdong.server.domain.club.ClubRepository;
+import woohakdong.server.domain.member.Member;
+import woohakdong.server.domain.member.MemberRepository;
+import woohakdong.server.domain.school.School;
+import woohakdong.server.domain.school.SchoolRepository;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class ClubServiceTest {
+
+    @Autowired
+    private ClubService clubService;
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private SchoolRepository schoolRepository;
+
+    @BeforeEach
+    void setUp() {
+        School school = School.builder()
+                .schoolDomain("ajou.ac.kr")
+                .schoolName("아주대학교")
+                .build();
+        schoolRepository.save(school);
+
+        Member member = Member.builder()
+                .memberProvideId("testProvideId")
+                .memberName("John Doe")
+                .memberRole("USER_ROLE")
+                .memberEmail("")
+                .school(school)
+                .build();
+        memberRepository.save(member);
+
+        // SecurityContext에 CustomUserDetails 설정
+        String provideId = "testProvideId";
+        String role = "USER_ROLE";
+        CustomUserDetails customUserDetails = new CustomUserDetails(provideId, role);
+        UsernamePasswordAuthenticationToken authToken =
+                new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+
+    @DisplayName("동아리를 등록하면, JOIN 타입의 모임이 생성된다.")
+    @Test
+    void registerClub() {
+        // Given
+        ClubCreateRequest clubCreateRequest = ClubCreateRequest.builder()
+                .clubName("두리안")
+                .clubEnglishName("Durian")
+                .clubDues(10000)
+                .clubGeneration("33")
+                .build();
+
+        // When
+        ClubCreateResponse clubCreateResponse = clubService.registerClub(clubCreateRequest);
+
+        // Then
+        Optional<Club> optionalClub = clubRepository.findById(clubCreateResponse.clubId());
+        assertThat(optionalClub).isPresent();
+        Club club = optionalClub.get();
+
+        assertThat(club.getClubName()).isEqualTo("두리안");
+        assertThat(club.getClubEnglishName()).isEqualTo("Durian");
+        assertThat(clubCreateResponse.clubId()).isEqualTo(club.getClubId());
+        assertThat(club.getGatherings().size()).isEqualTo(1);
+        assertThat(club.getGatherings().get(0).getGatheringAmount()).isEqualTo(10000);
+        assertThat(club.getGatherings().get(0).getGatheringType()).isEqualTo(JOIN);
+    }
+}

--- a/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
@@ -1,6 +1,7 @@
 package woohakdong.server.api.service.club;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static woohakdong.server.domain.clubmember.ClubMemberRole.PRESIDENT;
 import static woohakdong.server.domain.gathering.GatheringType.JOIN;
 
 import java.util.Optional;
@@ -13,11 +14,14 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+import woohakdong.server.api.controller.club.dto.ClubAccountRegisterRequest;
 import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
 import woohakdong.server.api.controller.club.dto.ClubCreateResponse;
 import woohakdong.server.common.security.jwt.CustomUserDetails;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
+import woohakdong.server.domain.clubAccount.ClubAccount;
+import woohakdong.server.domain.clubAccount.ClubAccountRepository;
 import woohakdong.server.domain.member.Member;
 import woohakdong.server.domain.member.MemberRepository;
 import woohakdong.server.domain.school.School;
@@ -39,6 +43,8 @@ class ClubServiceTest {
 
     @Autowired
     private SchoolRepository schoolRepository;
+    @Autowired
+    private ClubAccountRepository clubAccountRepository;
 
     @BeforeEach
     void setUp() {
@@ -70,12 +76,7 @@ class ClubServiceTest {
     @Test
     void registerClub() {
         // Given
-        ClubCreateRequest clubCreateRequest = ClubCreateRequest.builder()
-                .clubName("두리안")
-                .clubEnglishName("Durian")
-                .clubDues(10000)
-                .clubGeneration("33")
-                .build();
+        ClubCreateRequest clubCreateRequest = createClubCreateRequest();
 
         // When
         ClubCreateResponse clubCreateResponse = clubService.registerClub(clubCreateRequest);
@@ -91,5 +92,58 @@ class ClubServiceTest {
         assertThat(club.getGatherings().size()).isEqualTo(1);
         assertThat(club.getGatherings().get(0).getGatheringAmount()).isEqualTo(10000);
         assertThat(club.getGatherings().get(0).getGatheringType()).isEqualTo(JOIN);
+    }
+
+    @DisplayName("동아리를 등록하면, 등록한 사람이 회장으로 등록된다.")
+    @Test
+    void test() {
+        // Given
+        ClubCreateRequest clubCreateRequest = createClubCreateRequest();
+
+        // When
+        ClubCreateResponse clubCreateResponse = clubService.registerClub(clubCreateRequest);
+
+        // Then
+        Optional<Club> optionalClub = clubRepository.findById(clubCreateResponse.clubId());
+        assertThat(optionalClub).isPresent();
+        Club club = optionalClub.get();
+
+        assertThat(club.getClubMembers().size()).isEqualTo(1);
+        assertThat(club.getClubMembers().get(0).getClubMemberRole()).isEqualTo(PRESIDENT);
+        assertThat(club.getClubMembers().get(0).getMember().getMemberProvideId()).isEqualTo("testProvideId");
+    }
+
+    @DisplayName("동아리 회장은 동아리 계좌를 등록할 수 있다.")
+    @Test
+    void registerClubAccount() {
+        // Given
+        ClubCreateRequest clubCreateRequest = createClubCreateRequest();
+        Long clubId = clubService.registerClub(clubCreateRequest).clubId();
+        Club club = clubRepository.findById(clubId).get();
+
+        ClubAccountRegisterRequest clubAccountRegisterRequest = ClubAccountRegisterRequest.builder()
+                .clubAccountBankName("국민은행")
+                .clubAccountNumber("1234567890")
+                .clubAccountPinTechNumber("123456")
+                .build();
+        
+        // When
+        clubService.registerClubAccount(clubId, clubAccountRegisterRequest);
+    	
+        // Then
+        Optional<ClubAccount> clubAccount = clubAccountRepository.findByClub(club);
+
+        assertThat(clubAccount).isPresent();
+        assertThat(clubAccount.get().getClubAccountBankName()).isEqualTo("국민은행");
+        assertThat(clubAccount.get().getClubAccountNumber()).isEqualTo("1234567890");
+    }
+
+    private ClubCreateRequest createClubCreateRequest() {
+        return ClubCreateRequest.builder()
+                .clubName("두리안")
+                .clubEnglishName("Durian")
+                .clubDues(10000)
+                .clubGeneration("33")
+                .build();
     }
 }

--- a/src/test/java/woohakdong/server/domain/clubAccount/ClubAccountRepositoryTest.java
+++ b/src/test/java/woohakdong/server/domain/clubAccount/ClubAccountRepositoryTest.java
@@ -1,0 +1,54 @@
+package woohakdong.server.domain.clubAccount;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import woohakdong.server.domain.club.Club;
+import woohakdong.server.domain.club.ClubRepository;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class ClubAccountRepositoryTest {
+
+    @Autowired
+    private ClubAccountRepository clubAccountRepository;
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    @DisplayName("은행 이름과 계좌 번호로 계좌 존재 여부를 확인한다.")
+    @Test
+    void existsByClubAccountBankNameAndClubAccountNumber() {
+        // Given
+        Club club = Club.builder()
+                .clubName("테스트동아리")
+                .clubEnglishName("testClub")
+                .build();
+        clubRepository.save(club);
+
+        ClubAccount clubAccount = ClubAccount.builder()
+                .clubAccountBankName("테스트은행")
+                .clubAccountNumber("1111111111")
+                .clubAccountPinTechNumber("PIN-11111111")
+                .club(club)
+                .build();
+        clubAccountRepository.save(clubAccount);
+
+        // When
+        Boolean result1 = clubAccountRepository.existsByClubAccountBankNameAndClubAccountNumber(clubAccount.getClubAccountBankName(), clubAccount.getClubAccountNumber());
+        Boolean result2 = clubAccountRepository.existsByClubAccountBankNameAndClubAccountNumber("nonexistent", clubAccount.getClubAccountNumber());
+        Boolean result3 = clubAccountRepository.existsByClubAccountBankNameAndClubAccountNumber(clubAccount.getClubAccountBankName(), "nonexistent");
+
+        // Then
+        assertThat(result1).isTrue();
+        assertThat(result2).isFalse();
+        assertThat(result3).isFalse();
+    }
+
+}

--- a/src/test/java/woohakdong/server/domain/clubAccount/ClubAccountRepositoryTest.java
+++ b/src/test/java/woohakdong/server/domain/clubAccount/ClubAccountRepositoryTest.java
@@ -2,6 +2,7 @@ package woohakdong.server.domain.clubAccount;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,14 +42,46 @@ class ClubAccountRepositoryTest {
         clubAccountRepository.save(clubAccount);
 
         // When
-        Boolean result1 = clubAccountRepository.existsByClubAccountBankNameAndClubAccountNumber(clubAccount.getClubAccountBankName(), clubAccount.getClubAccountNumber());
-        Boolean result2 = clubAccountRepository.existsByClubAccountBankNameAndClubAccountNumber("nonexistent", clubAccount.getClubAccountNumber());
-        Boolean result3 = clubAccountRepository.existsByClubAccountBankNameAndClubAccountNumber(clubAccount.getClubAccountBankName(), "nonexistent");
+        Boolean result1 = clubAccountRepository.existsByClubAccountBankNameAndClubAccountNumber(
+                clubAccount.getClubAccountBankName(), clubAccount.getClubAccountNumber());
+        Boolean result2 = clubAccountRepository.existsByClubAccountBankNameAndClubAccountNumber("nonexistent",
+                clubAccount.getClubAccountNumber());
+        Boolean result3 = clubAccountRepository.existsByClubAccountBankNameAndClubAccountNumber(
+                clubAccount.getClubAccountBankName(), "nonexistent");
 
         // Then
         assertThat(result1).isTrue();
         assertThat(result2).isFalse();
         assertThat(result3).isFalse();
+    }
+
+    @DisplayName("동아리 정보로 계좌 정보를 조회한다.")
+    @Test
+    void test() {
+        // Given
+        Club club = Club.builder()
+                .clubName("테스트동아리")
+                .clubEnglishName("testClub")
+                .build();
+        clubRepository.save(club);
+
+        ClubAccount clubAccount = ClubAccount.builder()
+                .clubAccountBankName("테스트은행")
+                .clubAccountNumber("1111111111")
+                .clubAccountPinTechNumber("PIN-11111111")
+                .club(club)
+                .build();
+        clubAccountRepository.save(clubAccount);
+
+        // When
+        Optional<ClubAccount> optionalClubAccount = clubAccountRepository.findByClub(club);
+
+        // Then
+        assertThat(optionalClubAccount).isPresent();
+        ClubAccount foundClubAccount = optionalClubAccount.get();
+
+        assertThat(foundClubAccount).extracting("clubAccountBankName", "clubAccountPinTechNumber")
+                .containsExactly("테스트은행", "PIN-11111111");
     }
 
 }

--- a/src/test/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryTest.java
+++ b/src/test/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryTest.java
@@ -55,12 +55,16 @@ class ClubMemberRepositoryTest {
         clubRepository.save(club);
 
         Member member1 = Member.builder()
+                .memberProvideId("testProvideId")
                 .memberName("일반 회원 이름")
+                .memberEmail("user@ajou.ac.kr")
                 .school(school)
                 .build();
 
         Member member2 = Member.builder()
+                .memberProvideId("testProvideId2")
                 .memberName("회장 회원 이름")
+                .memberEmail("president@ajou.ac.kr")
                 .school(school)
                 .build();
         memberRepository.saveAll(List.of(member1, member2));

--- a/src/test/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryTest.java
+++ b/src/test/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryTest.java
@@ -66,7 +66,6 @@ class ClubMemberRepositoryTest {
         memberRepository.saveAll(List.of(member1, member2));
 
         ClubMember clubMember1 = ClubMember.builder()
-                .clubJoinedDate(LocalDate.now())
                 .clubMemberAssignedTerm(LocalDate.now())
                 .club(club)
                 .member(member1)
@@ -74,7 +73,6 @@ class ClubMemberRepositoryTest {
                 .build();
 
         ClubMember clubMember2 = ClubMember.builder()
-                .clubJoinedDate(LocalDate.now())
                 .clubMemberAssignedTerm(LocalDate.now())
                 .club(club)
                 .member(member2)

--- a/src/test/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryTest.java
+++ b/src/test/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryTest.java
@@ -1,0 +1,103 @@
+package woohakdong.server.domain.clubmember;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static woohakdong.server.domain.clubmember.ClubMemberRole.MEMBER;
+import static woohakdong.server.domain.clubmember.ClubMemberRole.OFFICER;
+import static woohakdong.server.domain.clubmember.ClubMemberRole.PRESIDENT;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import woohakdong.server.domain.club.Club;
+import woohakdong.server.domain.club.ClubRepository;
+import woohakdong.server.domain.member.Member;
+import woohakdong.server.domain.member.MemberRepository;
+import woohakdong.server.domain.school.School;
+import woohakdong.server.domain.school.SchoolRepository;
+
+@SpringBootTest
+@Transactional
+class ClubMemberRepositoryTest {
+
+    @Autowired
+    private ClubMemberRepository clubMemberRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    @Autowired
+    private SchoolRepository schoolRepository;
+
+    @DisplayName("동아리에 가입한 회원에 대해 역할이 부여되었는지 확인한다.")
+    @Test
+    void existsByClubAndMemberAndClubMemberRole() {
+        // Given
+        School school = School.builder()
+                .schoolDomain("ajou.ac.kr")
+                .schoolName("아주대학교")
+                .build();
+        schoolRepository.save(school);
+
+        Club club = Club.builder()
+                .clubName("테스트동아리")
+                .clubEnglishName("testClub")
+                .school(school)
+                .build();
+        clubRepository.save(club);
+
+        Member member1 = Member.builder()
+                .memberName("일반 회원 이름")
+                .school(school)
+                .build();
+
+        Member member2 = Member.builder()
+                .memberName("회장 회원 이름")
+                .school(school)
+                .build();
+        memberRepository.saveAll(List.of(member1, member2));
+
+        ClubMember clubMember1 = ClubMember.builder()
+                .clubJoinedDate(LocalDate.now())
+                .clubMemberAssignedTerm(LocalDate.now())
+                .club(club)
+                .member(member1)
+                .clubMemberRole(MEMBER)
+                .build();
+
+        ClubMember clubMember2 = ClubMember.builder()
+                .clubJoinedDate(LocalDate.now())
+                .clubMemberAssignedTerm(LocalDate.now())
+                .club(club)
+                .member(member2)
+                .clubMemberRole(OFFICER)
+                .build();
+        clubMemberRepository.saveAll(List.of(clubMember1, clubMember2));
+
+
+        // When
+        Boolean result1 = clubMemberRepository.existsByClubAndMemberAndClubMemberRole(club, member1, MEMBER);
+        Boolean result2 = clubMemberRepository.existsByClubAndMemberAndClubMemberRole(club, member1, PRESIDENT);
+        Boolean result3 = clubMemberRepository.existsByClubAndMemberAndClubMemberRole(club, member1, OFFICER);
+        Boolean result4 = clubMemberRepository.existsByClubAndMemberAndClubMemberRole(club, member2, MEMBER);
+        Boolean result5 = clubMemberRepository.existsByClubAndMemberAndClubMemberRole(club, member2, PRESIDENT);
+        Boolean result6 = clubMemberRepository.existsByClubAndMemberAndClubMemberRole(club, member2, OFFICER);
+
+        // Then
+        assertThat(result1).isTrue();
+        assertThat(result2).isFalse();
+        assertThat(result3).isFalse();
+        assertThat(result4).isFalse();
+        assertThat(result5).isFalse();
+        assertThat(result6).isTrue();
+    }
+
+}


### PR DESCRIPTION
### 기능 설명
1. 동아리명 검증하기
2. 동아리 등록하기
3. 동아리 계좌 검증하기
4. 동아리 계좌 등록하기

### 작성 상세 내용
유저가 동아리 등록 시 다음과 같은 로직이 이루어진다.
1. Club 생성
2. Gathering JOIN 타입으로 추가 ( 동아리 회원 등록용 Gathering )
3. ClubMember에 PRESIDENT로 등록

**서비스 로직 작성 간에 가독성을 높이기 위해서 최대한 private method로 처리**

### 관련 지라 티켓 번호
[WHD-99] 동아리 이름 조회 및 동아리 등록 API 개발 및 유효성 검증 #done

[WHD-99]: https://8901dev.atlassian.net/browse/WHD-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ