### PR TITLE
[WHD-123] Feat: Setup portone config

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -110,6 +110,8 @@ jobs:
             echo "COMMIT_SHA=${{ needs.build.outputs.commit_sha }}" >> .env
             echo "AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID }}" >> .env
             echo "ECR_REPOSITORY=${{ secrets.ECR_REPOSITORY }}" >> .env
+            ehoc "PORTONE_REST_API_KEY=${{ secrets.PORTONE_REST_API_KEY }}" >> .env
+            echo "PORTONE_REST_API_SECRET=${{ secrets.PORTONE_REST_API_SECRET }}" >> .env
             
             aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.ap-northeast-2.amazonaws.com
             

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,16 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven{
+        url 'https://jitpack.io'
+    }
 }
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -43,6 +48,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
 }
 
 tasks.named('test') {

--- a/src/main/java/woohakdong/server/common/config/PortOneConfig.java
+++ b/src/main/java/woohakdong/server/common/config/PortOneConfig.java
@@ -1,0 +1,21 @@
+package woohakdong.server.common.config;
+
+import com.siot.IamportRestClient.IamportClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+@Configuration
+public class PortOneConfig {
+
+    @Value("${portone.rest.api.key}")
+    private String restApiKey;
+    @Value("${portone.rest.api.secret}")
+    private String restApiSecret;
+
+    @Bean
+    public IamportClient iamportClient() {
+        return new IamportClient(restApiKey, restApiSecret);
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -13,3 +13,9 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+
+portone:
+  rest:
+    api:
+      key: your_test_key
+      secret: your_test_secret

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,9 @@ spring:
     name: woohakdong-server
   jwt:
     secret: fklwnvndfjlsdkjevealkekfnkevkenflwjkfjlsdjvoiwenbfklhaedsf
+
+portone:
+  rest:
+    api:
+      key: ${PORTONE_API_KEY}
+      secret: ${PORTONE_API_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,5 +7,5 @@ spring:
 portone:
   rest:
     api:
-      key: ${PORTONE_API_KEY}
-      secret: ${PORTONE_API_SECRET}
+      key: ${PORTONE_REST_API_KEY}
+      secret: ${PORTONE_REST_API_SECRET}

--- a/src/test/java/woohakdong/server/WoohakdongServerApplicationTests.java
+++ b/src/test/java/woohakdong/server/WoohakdongServerApplicationTests.java
@@ -2,7 +2,9 @@ package woohakdong.server;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class WoohakdongServerApplicationTests {
 

--- a/src/test/java/woohakdong/server/api/service/aws/AwsServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/aws/AwsServiceTest.java
@@ -9,8 +9,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 
+@ActiveProfiles("test")
 @SpringBootTest
 class AwsServiceTest {
 

--- a/src/test/java/woohakdong/server/api/service/util/UtilServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/util/UtilServiceTest.java
@@ -9,9 +9,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import woohakdong.server.api.controller.util.dto.S3PresignedUrlResponse;
 import woohakdong.server.common.exception.CustomException;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class UtilServiceTest {
 

--- a/src/test/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryTest.java
+++ b/src/test/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
@@ -21,6 +22,7 @@ import woohakdong.server.domain.member.MemberRepository;
 import woohakdong.server.domain.school.School;
 import woohakdong.server.domain.school.SchoolRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 class ClubMemberRepositoryTest {


### PR DESCRIPTION
### 기능 설명
PortOne 사용 설정

### 작성 상세 내용
1. PortOne 의존성 추가
2. 결제 검증을 위한 IamportClient Bean 등록
3. GitHub Secrets에 PortOne 관련 정보 저장

### 관련 지라 티켓 번호
[WHD-123]

[WHD-123]: https://8901dev.atlassian.net/browse/WHD-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

skip deploy