### PR TITLE
[WHD-149] Feat: Club info edit api

### DIFF
--- a/src/main/java/woohakdong/server/api/controller/club/ClubController.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubController.java
@@ -38,8 +38,8 @@ public class ClubController implements ClubControllerDocs {
     }
 
     @PutMapping("/{clubId}")
-    public ClubInfoResponse updateClubInfo(@PathVariable Long clubId, @RequestBody ClubCreateRequest request) {
-        return null;
+    public ClubInfoResponse updateClubInfo(@PathVariable Long clubId, @RequestBody ClubUpdateRequest request) {
+        return clubService.updateClubInfo(clubId, request);
     }
 
     @PostMapping("/{clubId}/accounts")

--- a/src/main/java/woohakdong/server/api/controller/club/ClubControllerDocs.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubControllerDocs.java
@@ -27,9 +27,9 @@ public interface ClubControllerDocs {
     public ClubInfoResponse getClubInfo(Long clubId);
 
     @SecurityRequirement(name = "accessToken")
-    @Operation(summary = "동아리 정보 수정 (진행 중)", description = "수정할 동아리 정보를 제공하면, 해당 동아리의 정보를 수정합니다.")
+    @Operation(summary = "동아리 정보 수정", description = "수정할 동아리 정보를 제공하면, 해당 동아리의 정보를 수정합니다.")
     @ApiResponse(responseCode = "200", description = "동아리 정보 수정 성공", useReturnTypeSchema = true)
-    public ClubInfoResponse updateClubInfo(Long clubId, ClubCreateRequest clubCreateRequest);
+    public ClubInfoResponse updateClubInfo(Long clubId, ClubUpdateRequest clubCreateRequest);
 
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "동아리 계좌 등록", description = "동아리에서 사용하는 계좌 정보를 등록합니다.")

--- a/src/main/java/woohakdong/server/api/controller/club/dto/ClubUpdateRequest.java
+++ b/src/main/java/woohakdong/server/api/controller/club/dto/ClubUpdateRequest.java
@@ -1,0 +1,25 @@
+package woohakdong.server.api.controller.club.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record ClubUpdateRequest(
+        String clubImage,
+
+        @NotNull(message = "동아리 설명은 필수 입력 값입니다.")
+        String clubDescription,
+
+        String clubRoom,
+
+        String clubGeneration,
+
+        @NotNull(message = "동아리 단체 채팅 링크는 필수 입력 값입니다.")
+        String clubGroupChatLink,
+
+        String clubGroupChatPassword,
+
+        @NotNull(message = "회비는 필수 입력 값입니다.")
+        Integer clubDues
+) {
+}

--- a/src/main/java/woohakdong/server/common/data/DataInitializer.java
+++ b/src/main/java/woohakdong/server/common/data/DataInitializer.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import woohakdong.server.domain.admin.adminAccount.AdminAccount;
 import woohakdong.server.domain.admin.adminAccount.AdminAccountRepository;
@@ -26,6 +27,7 @@ import woohakdong.server.domain.school.SchoolRepository;
 
 @RequiredArgsConstructor
 @Component
+@Profile("dev")
 public class DataInitializer implements CommandLineRunner {
 
     private final SchoolRepository schoolRepository;

--- a/src/main/java/woohakdong/server/domain/club/Club.java
+++ b/src/main/java/woohakdong/server/domain/club/Club.java
@@ -17,6 +17,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.api.controller.club.dto.ClubUpdateRequest;
 import woohakdong.server.domain.clubHistory.ClubHistory;
 import woohakdong.server.domain.clubmember.ClubMember;
 import woohakdong.server.domain.group.Group;
@@ -81,5 +82,14 @@ public class Club {
 
     public void addClubHistory(ClubHistory clubHistory) {
         this.clubHistorys.add(clubHistory);
+    }
+
+    public void updateClubInfo(String clubImage, String clubDescription, String clubRoom, String clubGeneration,
+                               Integer clubDues) {
+        this.clubImage = clubImage;
+        this.clubDescription = clubDescription;
+        this.clubRoom = clubRoom;
+        this.clubGeneration = clubGeneration;
+        this.clubDues = clubDues;
     }
 }

--- a/src/main/java/woohakdong/server/domain/group/Group.java
+++ b/src/main/java/woohakdong/server/domain/group/Group.java
@@ -48,6 +48,8 @@ public class Group {
 
     private String groupChatPassword;
 
+    private Boolean groupIsAvailable;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_id")
     private Club club;
@@ -64,7 +66,12 @@ public class Group {
         this.groupJoinLink = groupJoinLink;
         this.groupChatLink = groupChatLink;
         this.groupChatPassword = groupChatPassword;
+        this.groupIsAvailable = true;
         this.groupType = groupType;
         this.club = club;
+    }
+
+    public void disableGroup() {
+        this.groupIsAvailable = false;
     }
 }

--- a/src/main/java/woohakdong/server/domain/group/GroupRepository.java
+++ b/src/main/java/woohakdong/server/domain/group/GroupRepository.java
@@ -8,7 +8,7 @@ import woohakdong.server.domain.club.Club;
 public interface GroupRepository extends JpaRepository<Group, Long> {
 
     // JOIN에 해당하는 Gathering을 찾는 메소드
-    Optional<Group> findByClubAndGroupType(Club club, GroupType groupType);
+    Optional<Group> findByClubAndGroupTypeAndGroupIsAvailable(Club club, GroupType groupType, Boolean groupIsAvailable);
 
     // Event에 해당하는 Gathering을 찾는 메소드
     List<Group> findAllByClubAndGroupType(Club club, GroupType groupType);

--- a/src/test/java/woohakdong/server/api/service/auth/AuthServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/auth/AuthServiceTest.java
@@ -1,31 +1,35 @@
 package woohakdong.server.api.service.auth;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static woohakdong.server.common.exception.CustomErrorInfo.INVALID_SCHOOL_DOMAIN;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.common.exception.CustomException;
-import woohakdong.server.domain.member.MemberRepository;
 import woohakdong.server.domain.school.School;
 import woohakdong.server.domain.school.SchoolRepository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import static woohakdong.server.common.exception.CustomErrorInfo.*;
-
 @ActiveProfiles("test")
 @SpringBootTest
+@Transactional
 class AuthServiceTest {
 
     @Autowired
     private AuthService authService;
 
+    @Autowired
+    private SchoolRepository schoolRepository;
+
     @DisplayName("학교 도메인인 구글 이메일로만 로그인 할 수 있다.")
     @Test
     void schoolDomainValidation() {
         // given
+        createSchool();
         String email = "uiyeop@ajou.ac.kr";
 
         //when
@@ -42,11 +46,20 @@ class AuthServiceTest {
     @Test
     void schoolDomainInValidation() {
         // given
+        createSchool();
         String email = "uiyeop@gmail.com";
 
         //when & then
         assertThatThrownBy(() -> authService.checkSchoolDomain(email))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(INVALID_SCHOOL_DOMAIN.getMessage());
+    }
+
+    private School createSchool() {
+        School school = School.builder()
+                .schoolName("아주대학교")
+                .schoolDomain("ajou.ac.kr")
+                .build();
+        return schoolRepository.save(school);
     }
 }

--- a/src/test/java/woohakdong/server/domain/group/GroupRepositoryTest.java
+++ b/src/test/java/woohakdong/server/domain/group/GroupRepositoryTest.java
@@ -29,7 +29,7 @@ class GroupRepositoryTest {
 
     @DisplayName("동아리의 가입용 그룹을 조회할 수 있다.")
     @Test
-    void findByClubAndGroupType() {
+    void findByClubAndGroupTypeAndGroupIsAvailable() {
         // Given
         Club club = Club.builder()
                 .clubName("테스트 동아리")
@@ -53,7 +53,8 @@ class GroupRepositoryTest {
         groupRepository.saveAll(List.of(group1, group2));
 
         // When
-        Optional<Group> optionalGathering = groupRepository.findByClubAndGroupType(savedClub, JOIN);
+        Optional<Group> optionalGathering = groupRepository.findByClubAndGroupTypeAndGroupIsAvailable(savedClub, JOIN,
+                true);
 
         // Then
         assertThat(optionalGathering).isPresent();


### PR DESCRIPTION
### 기능 설명
- 동아리 정보 수정이 가능하다.

### 작성 상세 내용
- 동아리 정보 수정 시, 기존 그룹이 disable된다.
- 동아리 정보 수정 시, 수정 정보를 바탕으로 새 그룹이 생긴다.
- 테스트 코드 관련하여 리팩토링 진행

### 관련 지라 티켓 번호
[WHD-149]

### 참고 자료
[테스트 코드가 너무 더러워요](https://www.notion.so/jjunhub/12f69b3a7dff80df86ccc9dfa566187b?pvs=4)


[WHD-149]: https://8901dev.atlassian.net/browse/WHD-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ