### PR TITLE
[WHD-145] Feat: Club dues api

### DIFF
--- a/src/main/java/woohakdong/server/api/controller/dues/DuesController.java
+++ b/src/main/java/woohakdong/server/api/controller/dues/DuesController.java
@@ -1,0 +1,35 @@
+package woohakdong.server.api.controller.dues;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import woohakdong.server.api.controller.ListWrapperResponse;
+import woohakdong.server.api.controller.clubMember.dto.ClubMemberInfoResponse;
+import woohakdong.server.api.controller.dues.dto.ClubAccountHistoryListResponse;
+import woohakdong.server.api.service.dues.DuesService;
+import woohakdong.server.domain.clubAccountHistory.ClubAccountHistory;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/club")
+public class DuesController implements DuesControllerDocs {
+
+    private final DuesService duesService;
+
+    @PostMapping("/{clubId}/dues/update")
+    public void updateTransactions(@PathVariable Long clubId) {
+        duesService.fetchAndSaveRecentTransactions(clubId);
+    }
+
+    @GetMapping("/{clubId}/dues")
+    public ListWrapperResponse<ClubAccountHistoryListResponse> getMonthlyTransactions(
+            @PathVariable Long clubId,
+            @RequestParam int year,
+            @RequestParam int month) {
+
+        List<ClubAccountHistoryListResponse> historys = duesService.getMonthlyTransactions(clubId, year, month);
+        return ListWrapperResponse.of(historys);
+    }
+}

--- a/src/main/java/woohakdong/server/api/controller/dues/DuesControllerDocs.java
+++ b/src/main/java/woohakdong/server/api/controller/dues/DuesControllerDocs.java
@@ -3,11 +3,13 @@ package woohakdong.server.api.controller.dues;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import woohakdong.server.api.controller.ListWrapperResponse;
 import woohakdong.server.api.controller.dues.dto.ClubAccountHistoryListResponse;
 
+@Tag(name = "Dues", description = "회비 관련 API")
 public interface DuesControllerDocs {
 
     @SecurityRequirement(name = "accessToken")

--- a/src/main/java/woohakdong/server/api/controller/dues/DuesControllerDocs.java
+++ b/src/main/java/woohakdong/server/api/controller/dues/DuesControllerDocs.java
@@ -1,0 +1,25 @@
+package woohakdong.server.api.controller.dues;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import woohakdong.server.api.controller.ListWrapperResponse;
+import woohakdong.server.api.controller.dues.dto.ClubAccountHistoryListResponse;
+
+public interface DuesControllerDocs {
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "회비 내역 불러오기", description = "회장이 최근 업데이트한 날짜 부터 현재 시각까지 회비 내역 불러올 수 있다.")
+    @ApiResponse(responseCode = "200", description = "물품 대여 기록 조회 성공", useReturnTypeSchema = true)
+    public void updateTransactions(@PathVariable Long clubId);
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "월별 회비 내역 조회", description = "월별 회비 내역을 조회할 수 있다.")
+    @ApiResponse(responseCode = "200", description = "물품 대여 기록 조회 성공", useReturnTypeSchema = true)
+    public ListWrapperResponse<ClubAccountHistoryListResponse> getMonthlyTransactions(
+            @PathVariable Long clubId,
+            @RequestParam int year,
+            @RequestParam int month);
+}

--- a/src/main/java/woohakdong/server/api/controller/dues/dto/ClubAccountHistoryListResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/dues/dto/ClubAccountHistoryListResponse.java
@@ -1,0 +1,18 @@
+package woohakdong.server.api.controller.dues.dto;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import woohakdong.server.domain.admin.adminAccount.AccountType;
+
+import java.time.LocalDateTime;
+
+public record ClubAccountHistoryListResponse(
+        Long clubAccountHistoryId,
+        AccountType clubAccountHistoryInOutType,
+        LocalDateTime clubAccountHistoryTranDate,
+        Long clubAccountHistoryBalanceAmount,
+        Long clubAccountHistoryTranAmount,
+        String clubAccountHistoryContent
+) {
+}

--- a/src/main/java/woohakdong/server/api/service/bank/MockBankService.java
+++ b/src/main/java/woohakdong/server/api/service/bank/MockBankService.java
@@ -1,11 +1,9 @@
 package woohakdong.server.api.service.bank;
 
-import java.sql.SQLOutput;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/woohakdong/server/api/service/bank/MockBankService.java
+++ b/src/main/java/woohakdong/server/api/service/bank/MockBankService.java
@@ -35,6 +35,7 @@ import static woohakdong.server.common.exception.CustomErrorInfo.*;
 
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class MockBankService implements BankService {
 
     private final static Map<String, Map<String, String>> certifiedBanks = new HashMap<>();
@@ -171,6 +172,7 @@ public class MockBankService implements BankService {
         adminAccountRepository.save(adminAccount);  // 업데이트된 계좌 정보 저장
     }
 
+    @Transactional
     public List<ClubAccountHistory> fetchTransactions(ClubAccount clubAccount, LocalDate startDate, LocalDate endDate) {
         // 이체 요청 JSON 데이터 생성
         Map<String, Object> request = new HashMap<>();

--- a/src/main/java/woohakdong/server/api/service/bank/NHTransactionResponse.java
+++ b/src/main/java/woohakdong/server/api/service/bank/NHTransactionResponse.java
@@ -1,0 +1,43 @@
+package woohakdong.server.api.service.bank;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class NHTransactionResponse {
+    private Header Header;
+    private String TotCnt;
+    private String Iqtcnt;
+    private String CtntDataYn;
+    private List<Record> REC;
+
+    @Data
+    public static class Header {
+        private String Trtm;
+        private String Rsms;
+        private String ApiNm;
+        private String IsTuno;
+        private String Tsymd;
+        private String FintechApsno;
+        private String Iscd;
+        private String Rpcd;
+        private String ApiSvcCd;
+    }
+
+    @Data
+    public static class Record {
+        private String AftrBlnc;
+        private String TrnsAfAcntBlncSmblCd;
+        private String BnprCntn;
+        private String Txtm;
+        private String Tuno;
+        private String Trdd;
+        private String Smr;
+        private String Ccyn;
+        private String MnrcDrotDsnc;
+        private String Tram;
+        private String HnisCd;
+        private String HnbrCd;
+    }
+}

--- a/src/main/java/woohakdong/server/api/service/club/ClubService.java
+++ b/src/main/java/woohakdong/server/api/service/club/ClubService.java
@@ -11,6 +11,7 @@ import static woohakdong.server.domain.clubmember.ClubMemberRole.PRESIDENT;
 import static woohakdong.server.domain.group.GroupType.JOIN;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -203,6 +204,7 @@ public class ClubService {
                 .clubAccountNumber(clubAccountRegisterRequest.clubAccountNumber())
                 .clubAccountPinTechNumber(clubAccountRegisterRequest.clubAccountPinTechNumber())
                 .clubAccountBankCode(bankCode)
+                .clubAccountLastUpdateDate(LocalDateTime.now())
                 .club(club)
                 .build();
     }

--- a/src/main/java/woohakdong/server/api/service/dues/DuesService.java
+++ b/src/main/java/woohakdong/server/api/service/dues/DuesService.java
@@ -1,0 +1,78 @@
+package woohakdong.server.api.service.dues;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import woohakdong.server.api.controller.dues.dto.ClubAccountHistoryListResponse;
+import woohakdong.server.api.service.bank.MockBankService;
+import woohakdong.server.common.exception.CustomException;
+import woohakdong.server.domain.club.Club;
+import woohakdong.server.domain.club.ClubRepository;
+import woohakdong.server.domain.clubAccount.ClubAccount;
+import woohakdong.server.domain.clubAccount.ClubAccountRepository;
+import woohakdong.server.domain.clubAccountHistory.ClubAccountHistory;
+import woohakdong.server.domain.clubAccountHistory.ClubAccountHistoryRepository;
+import woohakdong.server.domain.member.MemberRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_ACCOUNT_NOT_FOUND;
+import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_NOT_FOUND;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DuesService {
+
+    private final ClubAccountHistoryRepository clubAccountHistoryRepository;
+    private final ClubRepository clubRepository;
+    private final ClubAccountRepository clubAccountRepository;
+    private final MockBankService mockBankService;
+
+    public void fetchAndSaveRecentTransactions(Long clubId) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new CustomException(CLUB_NOT_FOUND));
+
+        ClubAccount clubAccount = clubAccountRepository.findByClub(club)
+                .orElseThrow(() -> new CustomException(CLUB_ACCOUNT_NOT_FOUND));
+
+        LocalDateTime lastUpdateDate = clubAccount.getClubAccountLastUpdateDate() != null
+                ? clubAccount.getClubAccountLastUpdateDate()
+                : LocalDateTime.of(2000, 1, 1, 0, 0); // 기본값
+
+        // 오늘 날짜를 기준으로 거래 내역을 가져옴
+        List<ClubAccountHistory> histories = mockBankService.fetchTransactions(clubAccount, lastUpdateDate.toLocalDate(), LocalDate.now());
+
+        if (!histories.isEmpty()) {
+            clubAccountHistoryRepository.saveAll(histories);
+
+            clubAccount.setClubAccountLastUpdateDate(LocalDateTime.now());
+            clubAccountRepository.save(clubAccount);
+        }
+    }
+
+    public List<ClubAccountHistoryListResponse> getMonthlyTransactions(Long clubId, int year, int month) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new CustomException(CLUB_NOT_FOUND));
+
+        ClubAccount clubAccount = clubAccountRepository.findByClub(club)
+                .orElseThrow(() -> new CustomException(CLUB_ACCOUNT_NOT_FOUND));
+
+        List<ClubAccountHistory> histories = clubAccountHistoryRepository.findMonthlyTransactions(
+                clubAccount, year, month);
+
+        return histories.stream()
+                .map(history -> new ClubAccountHistoryListResponse(
+                        history.getClubAccountHistoryId(),
+                        history.getClubAccountHistoryInOutType(),
+                        history.getClubAccountHistoryTranDate(),
+                        history.getClubAccountHistoryBalanceAmount(),
+                        history.getClubAccountHistoryTranAmount(),
+                        history.getClubAccountHistoryContent()
+                ))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/woohakdong/server/common/exception/CustomErrorInfo.java
+++ b/src/main/java/woohakdong/server/common/exception/CustomErrorInfo.java
@@ -30,6 +30,8 @@ public enum CustomErrorInfo {
     ITEM_USING(400, "item using", 400022),
     ITEM_NOT_USING(400, "item not using", 400023),
     ITEM_HISTORY_NOT_FOUND(400, "item history not found", 400024),
+    CLUB_ACCOUNT_NOT_FOUND(400, "club account not found", 400025),
+    GET_TRANSACTION_FAILED(400, "get transaction failed", 400026),
 
     // 401 UNAUTHORIZED
     INVALID_ACCESS_TOKEN(401, "Invaild access token", 401001),

--- a/src/main/java/woohakdong/server/domain/clubAccount/ClubAccount.java
+++ b/src/main/java/woohakdong/server/domain/clubAccount/ClubAccount.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.clubAccountHistory.ClubAccountHistory;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -28,6 +29,9 @@ public class ClubAccount {
     @Column(nullable = false)
     private String clubAccountPinTechNumber;
 
+    @Column
+    private LocalDateTime clubAccountLastUpdateDate;
+
     @Column(nullable = false)
     private String clubAccountBankCode;
 
@@ -40,11 +44,16 @@ public class ClubAccount {
 
     @Builder
     public ClubAccount(Club club, String clubAccountBankName, String clubAccountNumber,
-                       String clubAccountPinTechNumber, String clubAccountBankCode) {
+                       String clubAccountPinTechNumber, String clubAccountBankCode, LocalDateTime clubAccountLastUpdateDate) {
         this.club = club;
         this.clubAccountBankName = clubAccountBankName;
         this.clubAccountNumber = clubAccountNumber;
         this.clubAccountPinTechNumber = clubAccountPinTechNumber;
         this.clubAccountBankCode = clubAccountBankCode;
+        this.clubAccountLastUpdateDate = clubAccountLastUpdateDate;
+    }
+
+    public void setClubAccountLastUpdateDate(LocalDateTime clubAccountLastUpdateDate) {
+        this.clubAccountLastUpdateDate = clubAccountLastUpdateDate;
     }
 }

--- a/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistory.java
+++ b/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistory.java
@@ -10,6 +10,7 @@ import woohakdong.server.domain.admin.adminAccount.AccountType;
 import woohakdong.server.domain.clubAccount.ClubAccount;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,7 +25,7 @@ public class ClubAccountHistory {
     private AccountType clubAccountHistoryInOutType;
 
     @Column(nullable = false)
-    private LocalDate clubAccountHistoryTranDate;
+    private LocalDateTime clubAccountHistoryTranDate;
 
     @Column(nullable = false)
     private Long clubAccountHistoryBalanceAmount;
@@ -40,7 +41,7 @@ public class ClubAccountHistory {
     private ClubAccount clubAccount;
 
     @Builder
-    public ClubAccountHistory(AccountType clubAccountHistoryInOutType, LocalDate clubAccountHistoryTranDate,
+    public ClubAccountHistory(AccountType clubAccountHistoryInOutType, LocalDateTime clubAccountHistoryTranDate,
                               Long clubAccountHistoryBalanceAmount, Long clubAccountHistoryTranAmount,
                               String clubAccountHistoryContent, ClubAccount clubAccount) {
         this.clubAccountHistoryInOutType = clubAccountHistoryInOutType;

--- a/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryRepository.java
@@ -1,6 +1,20 @@
 package woohakdong.server.domain.clubAccountHistory;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import woohakdong.server.domain.clubAccount.ClubAccount;
+
+import java.util.List;
 
 public interface ClubAccountHistoryRepository extends JpaRepository<ClubAccountHistory, Long> {
+
+    @Query("SELECT h FROM ClubAccountHistory h " +
+            "WHERE h.clubAccount = :clubAccount " +
+            "AND FUNCTION('YEAR', h.clubAccountHistoryTranDate) = :year " +
+            "AND FUNCTION('MONTH', h.clubAccountHistoryTranDate) = :month " +
+            "ORDER BY h.clubAccountHistoryTranDate DESC")
+    List<ClubAccountHistory> findMonthlyTransactions(@Param("clubAccount") ClubAccount clubAccount,
+                                                     @Param("year") int year,
+                                                     @Param("month") int month);
 }

--- a/src/test/java/woohakdong/server/api/service/dues/DuesServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/dues/DuesServiceTest.java
@@ -1,0 +1,50 @@
+package woohakdong.server.api.service.dues;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import woohakdong.server.domain.admin.adminAccount.AccountType;
+import woohakdong.server.domain.clubAccount.ClubAccount;
+import woohakdong.server.domain.clubAccount.ClubAccountRepository;
+import woohakdong.server.domain.clubAccountHistory.ClubAccountHistory;
+import woohakdong.server.domain.clubAccountHistory.ClubAccountHistoryRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class DuesServiceTest {
+    @Autowired
+    private ClubAccountHistoryRepository clubAccountHistoryRepository;
+
+    @Autowired
+    private ClubAccountRepository clubAccountRepository;
+
+    @Test
+    @DisplayName("특정 클럽의 월별 거래 내역을 조회할 수 있다")
+    void findMonthlyTransactions() {
+        // given
+        ClubAccount clubAccount = clubAccountRepository.save(new ClubAccount(null, "Test Bank", "1234567890", "0011223344", "011", LocalDateTime.now()));
+
+        clubAccountHistoryRepository.save(new ClubAccountHistory(AccountType.DEPOSIT, LocalDateTime.of(2024, 10, 15, 10, 0), 100000L, 10000L, "Test Deposit 1", clubAccount));
+        clubAccountHistoryRepository.save(new ClubAccountHistory(AccountType.WITHDRAW, LocalDateTime.of(2024, 10, 20, 15, 30), 90000L, 10000L, "Test Withdraw", clubAccount));
+        clubAccountHistoryRepository.save(new ClubAccountHistory(AccountType.DEPOSIT, LocalDateTime.of(2024, 11, 5, 11, 0), 100000L, 10000L, "Test Deposit 2", clubAccount));
+
+        int year = 2024;
+        int month = 10;
+
+        // when
+        List<ClubAccountHistory> histories = clubAccountHistoryRepository.findMonthlyTransactions(clubAccount, year, month);
+
+        // then
+        assertThat(histories).hasSize(2);
+        assertThat(histories).extracting("clubAccountHistoryContent").containsExactlyInAnyOrder("Test Deposit 1", "Test Withdraw");
+    }
+}


### PR DESCRIPTION
### 기능 설명
동아리 회장이 동아리 계좌 내역을 업데이트 가능하다.
동아리 계좌 내역을 월별로 조회할 수 있다.

### 작성 상세 내용
동아리 회장이 동아리 계좌 내역을 최근에 업데이트한 날부터 업데이트 한 시간까지 불러와 저장한다.
동아리 계좌 내역을 월별로 조회 가능하다.

### 관련 지라 티켓 번호
[WHD-145](https://8901dev.atlassian.net/browse/WHD-145)

### 참고 자료


[WHD-145]: https://8901dev.atlassian.net/browse/WHD-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ