### PR TITLE
[WHD-154] CI/CD: Implement Jacoco auto report

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
@@ -41,6 +42,16 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test --no-daemon
+
+      - name: Upload Test Coverage Report with Jacoco
+        uses: Madrapps/jacoco-report@v1.7.1
+        with:
+          title: Test Coverage Report
+          id: jacocoReport
+          paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 40
+          min-coverage-changed-files: 40
 
   build:
     name: Build And Push Docker Image

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'jacoco'
 }
 
 group = 'woohakdong'
@@ -11,6 +12,10 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
+}
+
+jacoco {
+    toolVersion = "0.8.11"
 }
 
 configurations {
@@ -71,5 +76,26 @@ dependencies {
 }
 
 tasks.named('test') {
+    finalizedBy jacocoTestReport
     useJUnitPlatform()
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = true
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            '**/*Application*',
+                            '**/*dto*',
+                            '**/*common*'
+                    ])
+                })
+        )
+    }
 }


### PR DESCRIPTION
### 기능 설명
- Jacoco를 통한 테스트 코드 커버리지 자동 분석

### 작성 상세 내용
- Jacoco 설정 완료
- PR 생성 시, 코드 커버리지를 분석하여 리포트를 자동으로 생성한다.

### 관련 지라 티켓 번호
[WHD-154]

### 참고 자료
- [Jacoco Docs](https://docs.gradle.org/current/userguide/jacoco_plugin.html)
- [Jacoco + GitHub Action 연동](https://creampuffy.tistory.com/193)


[WHD-154]: https://8901dev.atlassian.net/browse/WHD-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ