### PR TITLE
[WHD-130] Feat : Implement change ClubMember role

### DIFF
--- a/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberController.java
+++ b/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberController.java
@@ -7,7 +7,7 @@ import woohakdong.server.api.controller.clubMember.dto.ClubMemberInfoResponse;
 import woohakdong.server.api.service.clubMember.ClubMemberService;
 
 import java.time.LocalDate;
-import java.util.List;
+import woohakdong.server.domain.clubmember.ClubMemberRole;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +26,18 @@ public class ClubMemberController implements ClubMemberControllerDocs{
             // 모든 멤버 조회
             return ListWrapperResponse.of(clubMemberService.getMembers(clubId));
         }
+    }
+
+    @GetMapping("/{clubId}/members/me")
+    public ClubMemberInfoResponse getMyInfo(@PathVariable Long clubId) {
+        return null;
+    }
+
+    @PutMapping("/{clubId}/members/{clubMemberId}/role")
+    public void changeRole(@PathVariable Long clubId,
+                           @PathVariable Long clubMemberId,
+                           @RequestParam ClubMemberRole clubMemberRole) {
+
     }
 
 }

--- a/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberController.java
+++ b/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberController.java
@@ -1,23 +1,28 @@
 package woohakdong.server.api.controller.clubMember;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import woohakdong.server.api.controller.ListWrapperResponse;
 import woohakdong.server.api.controller.clubMember.dto.ClubMemberInfoResponse;
 import woohakdong.server.api.service.clubMember.ClubMemberService;
-
-import java.time.LocalDate;
 import woohakdong.server.domain.clubmember.ClubMemberRole;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/clubs")
-public class ClubMemberController implements ClubMemberControllerDocs{
+public class ClubMemberController implements ClubMemberControllerDocs {
 
     private final ClubMemberService clubMemberService;
 
     @GetMapping("/{clubId}/members")
-    public ListWrapperResponse<ClubMemberInfoResponse> getTermMembers(@PathVariable Long clubId, @RequestParam(required = false) LocalDate clubMemberAssignedTerm) {
+    public ListWrapperResponse<ClubMemberInfoResponse> getTermMembers(@PathVariable Long clubId,
+                                                                      @RequestParam(required = false) LocalDate clubMemberAssignedTerm) {
 
         if (clubMemberAssignedTerm != null) {
             // 학기로 필터링된 멤버 목록 조회
@@ -30,14 +35,13 @@ public class ClubMemberController implements ClubMemberControllerDocs{
 
     @GetMapping("/{clubId}/members/me")
     public ClubMemberInfoResponse getMyInfo(@PathVariable Long clubId) {
-        return null;
+        return clubMemberService.getMyInfo(clubId);
     }
 
     @PutMapping("/{clubId}/members/{clubMemberId}/role")
     public void changeRole(@PathVariable Long clubId,
                            @PathVariable Long clubMemberId,
                            @RequestParam ClubMemberRole clubMemberRole) {
-
+        clubMemberService.changeClubMemberRole(clubId, clubMemberId, clubMemberRole);
     }
-
 }

--- a/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberControllerDocs.java
+++ b/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberControllerDocs.java
@@ -5,24 +5,30 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import woohakdong.server.api.controller.ListWrapperResponse;
 import woohakdong.server.api.controller.clubMember.dto.ClubMemberInfoResponse;
 
 import java.time.LocalDate;
 import java.util.List;
+import woohakdong.server.domain.clubmember.ClubMemberRole;
 
-@Tag(name = "Club", description = "동아리 멤버 관련 API")
+@Tag(name = "Club Member", description = "동아리 멤버 관련 API")
 public interface ClubMemberControllerDocs {
-
-//    @SecurityRequirement(name = "accessToken")
-//    @Operation(summary = "동아리 소속 멤버 리스트 조회", description = "동아리 소속 멤버 리스트 조회하기")
-//    @ApiResponse(responseCode = "200", description = "동아리 소속 멤버 리스트 조회 성공", useReturnTypeSchema = true)
-//    @ApiResponse(responseCode = "400", description = "동아리 소속 멤버 리스트 조회 실패")
-//    public ListWrapperResponse<ClubMemberInfoResponse> getMembers(@PathVariable Long clubId);
 
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "동아리 소속 기수별 멤버 리스트 조회하기", description = "clubId와 기수(24-1)로 동아리 소속 기수별 멤버 리스트 조회하기 쿼리 파리미터가 없다면 현재 기수 조회")
     @ApiResponse(responseCode = "200", description = "동아리 소속 기수별 멤버 리스트 조회하기 성공", useReturnTypeSchema = true)
     @ApiResponse(responseCode = "400", description = "동아리 소속 기수별 멤버 리스트 조회하기 실패")
     public ListWrapperResponse<ClubMemberInfoResponse> getTermMembers(@PathVariable Long clubId, @PathVariable LocalDate clubMemberAssignedTerm);
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "동아리 내 나의 정보 불러오기", description = "동아리 내 정보인 Role과 clubMemberId를 불러온다.")
+    @ApiResponse(responseCode = "200", description = "동아리 내 나의 정보 불러오기 성공", useReturnTypeSchema = true)
+    public ClubMemberInfoResponse getMyInfo(@PathVariable Long clubId);
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "동아리 멤버의 역할 변경하기", description = "동아리 멤버의 Role을 변경한다.")
+    @ApiResponse(responseCode = "200", description = "동아리 멤버의 역할 변경하기 성공", useReturnTypeSchema = true)
+    public void changeRole(@PathVariable Long clubId, @PathVariable Long clubMemberId, @RequestParam ClubMemberRole clubMemberRole);
 }

--- a/src/main/java/woohakdong/server/api/controller/clubMember/dto/ClubMemberInfoResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/clubMember/dto/ClubMemberInfoResponse.java
@@ -1,6 +1,9 @@
 package woohakdong.server.api.controller.clubMember.dto;
 
 import lombok.Builder;
+import woohakdong.server.domain.clubmember.ClubMember;
+import woohakdong.server.domain.clubmember.ClubMemberRole;
+import woohakdong.server.domain.member.Member;
 import woohakdong.server.domain.member.MemberGender;
 
 import java.time.LocalDate;
@@ -11,13 +14,28 @@ public record ClubMemberInfoResponse(
         String memberName,
         String memberPhoneNumber,
         String memberEmail,
-        String memberSchool,
         MemberGender memberGender,
         String memberMajor,
         String memberStudentNumber,
-        String clubMemberRole,
+        ClubMemberRole clubMemberRole,
+        Long clubMemberId,
         LocalDate clubJoinedDate,
         LocalDate clubMemberAssignedTerm
 ) {
+    public static ClubMemberInfoResponse from(Member member, ClubMember clubMember) {
+        return ClubMemberInfoResponse.builder()
+                .memberId(member.getMemberId())
+                .memberName(member.getMemberName())
+                .memberPhoneNumber(member.getMemberPhoneNumber())
+                .memberEmail(member.getMemberEmail())
+                .memberMajor(member.getMemberMajor())
+                .memberStudentNumber(member.getMemberStudentNumber())
+                .memberGender(member.getMemberGender())
+                .clubMemberId(clubMember.getClubMemberId())
+                .clubMemberRole(clubMember.getClubMemberRole())
+                .clubJoinedDate(clubMember.getClubJoinedDate())
+                .clubMemberAssignedTerm(clubMember.getClubMemberAssignedTerm())
+                .build();
+    }
 
 }

--- a/src/main/java/woohakdong/server/api/service/club/ClubService.java
+++ b/src/main/java/woohakdong/server/api/service/club/ClubService.java
@@ -175,7 +175,7 @@ public class ClubService {
 
     private Group createJoinGroup(Club club) {
         return Group.builder()
-                .groupJoinLink("https://woohakdong.com/clubs/" + club.getClubEnglishName())
+                .groupJoinLink("https://www.woohakdong.com/clubs/" + club.getClubEnglishName())
                 .club(club)
                 .groupAmount(club.getClubDues())
                 .groupType(JOIN)

--- a/src/main/java/woohakdong/server/api/service/clubMember/ClubMemberService.java
+++ b/src/main/java/woohakdong/server/api/service/clubMember/ClubMemberService.java
@@ -1,18 +1,25 @@
 package woohakdong.server.api.service.clubMember;
 
+import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_MEMBER_ROLE_NOT_ALLOWED;
+import static woohakdong.server.common.exception.CustomErrorInfo.MEMBER_NOT_FOUND;
+
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.api.controller.clubMember.dto.ClubMemberInfoResponse;
+import woohakdong.server.common.exception.CustomException;
+import woohakdong.server.common.security.jwt.CustomUserDetails;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
 import woohakdong.server.domain.clubmember.ClubMember;
 import woohakdong.server.domain.clubmember.ClubMemberRepository;
+import woohakdong.server.domain.clubmember.ClubMemberRole;
 import woohakdong.server.domain.member.Member;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
+import woohakdong.server.domain.member.MemberRepository;
 
 @Service
 @Transactional(readOnly = true)
@@ -21,51 +28,49 @@ public class ClubMemberService {
 
     private final ClubMemberRepository clubMemberRepository;
     private final ClubRepository clubRepository;
+    private final MemberRepository memberRepository;
 
     public List<ClubMemberInfoResponse> getMembers(Long clubId) {
         Club club = clubRepository.getById(clubId);
         LocalDate assignedTerm = getAssignedTerm();
 
-        List<ClubMember> clubMembers = clubMemberRepository.getByClubIdAndAssignedTerm(club, assignedTerm);
+        List<ClubMember> clubMembers = clubMemberRepository.getByClubAndAssignedTerm(club, assignedTerm);
 
-        return clubMembers.stream().map(clubMember -> {
-            Member member = clubMember.getMember();
-            return ClubMemberInfoResponse.builder()
-                    .memberId(member.getMemberId())
-                    .memberName(member.getMemberName())
-                    .memberPhoneNumber(member.getMemberPhoneNumber())
-                    .memberEmail(member.getMemberEmail())
-                    .memberSchool(member.getSchool().getSchoolName())
-                    .memberMajor(member.getMemberMajor())
-                    .memberStudentNumber(member.getMemberStudentNumber())
-                    .memberGender(member.getMemberGender())
-                    .clubMemberRole(clubMember.getClubMemberRole().name())
-                    .clubJoinedDate(clubMember.getClubJoinedDate())
-                    .clubMemberAssignedTerm(clubMember.getClubMemberAssignedTerm())
-                    .build();
-        }).collect(Collectors.toList());
+        return clubMembers.stream()
+                .map(clubMember -> ClubMemberInfoResponse.from(clubMember.getMember(), clubMember))
+                .toList();
     }
 
     public List<ClubMemberInfoResponse> getTermMembers(Long clubId, LocalDate clubMemberAssignedTerm) {
         Club club = clubRepository.getById(clubId);
-        List<ClubMember> clubMembers = clubMemberRepository.getByClubIdAndAssignedTerm(club, clubMemberAssignedTerm);
+        List<ClubMember> clubMembers = clubMemberRepository.getByClubAndAssignedTerm(club, clubMemberAssignedTerm);
 
-        return clubMembers.stream().map(clubMember -> {
-            Member member = clubMember.getMember();
-            return ClubMemberInfoResponse.builder()
-                    .memberId(member.getMemberId())
-                    .memberName(member.getMemberName())
-                    .memberPhoneNumber(member.getMemberPhoneNumber())
-                    .memberEmail(member.getMemberEmail())
-                    .memberSchool(member.getSchool().getSchoolName())
-                    .memberMajor(member.getMemberMajor())
-                    .memberStudentNumber(member.getMemberStudentNumber())
-                    .memberGender(member.getMemberGender())
-                    .clubMemberRole(clubMember.getClubMemberRole().name())
-                    .clubJoinedDate(clubMember.getClubJoinedDate())
-                    .clubMemberAssignedTerm(clubMember.getClubMemberAssignedTerm())
-                    .build();
-        }).collect(Collectors.toList());
+        return clubMembers.stream()
+                .map(clubMember -> ClubMemberInfoResponse.from(clubMember.getMember(), clubMember))
+                .toList();
+    }
+
+    public ClubMemberInfoResponse getMyInfo(Long clubId) {
+        Member member = getMemberFromJwtInformation();
+        Club club = clubRepository.getById(clubId);
+        LocalDate assignedTerm = getAssignedTerm();
+
+        ClubMember clubMember = clubMemberRepository.getByClubAndMemberAndAssignedTerm(club, member, assignedTerm);
+
+        return ClubMemberInfoResponse.from(clubMember.getMember(), clubMember);
+    }
+
+    public void changeClubMemberRole(Long clubId, Long clubMemberId, ClubMemberRole clubMemberRole) {
+        Member member = getMemberFromJwtInformation();
+        Club club = clubRepository.getById(clubId);
+        ClubMember requestMember = clubMemberRepository.getByClubAndMember(club, member);
+
+        if (!requestMember.getClubMemberRole().equals(ClubMemberRole.PRESIDENT)) {
+            throw new CustomException(CLUB_MEMBER_ROLE_NOT_ALLOWED);
+        }
+
+        ClubMember clubMember = clubMemberRepository.getById(clubMemberId);
+        clubMember.changeRole(clubMemberRole);
     }
 
     private LocalDate getAssignedTerm() {
@@ -73,5 +78,14 @@ public class ClubMemberService {
         int year = now.getYear();
         int semester = now.getMonthValue() <= 6 ? 1 : 7; // 1: 1학기, 7: 2학기
         return LocalDate.of(year, semester, 1);
+    }
+
+    private Member getMemberFromJwtInformation() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        String provideId = userDetails.getUsername();
+
+        return memberRepository.findByMemberProvideId(provideId)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/woohakdong/server/api/service/clubMember/ClubMemberService.java
+++ b/src/main/java/woohakdong/server/api/service/clubMember/ClubMemberService.java
@@ -60,6 +60,7 @@ public class ClubMemberService {
         return ClubMemberInfoResponse.from(clubMember.getMember(), clubMember);
     }
 
+    @Transactional
     public void changeClubMemberRole(Long clubId, Long clubMemberId, ClubMemberRole clubMemberRole) {
         Member member = getMemberFromJwtInformation();
         Club club = clubRepository.getById(clubId);

--- a/src/main/java/woohakdong/server/common/data/DataInitializer.java
+++ b/src/main/java/woohakdong/server/common/data/DataInitializer.java
@@ -55,8 +55,8 @@ public class DataInitializer implements CommandLineRunner {
 
             Member member1 = Member.builder()
                     .memberEmail("sangjun@ajou.ac.kr")
-                    .memberRole("ROLE_USER")
-                    .memberName("박상준")
+                    .memberRole("USER_ROLE")
+                    .memberName("박상")
                     .memberProvideId("google_test")
                     .memberMajor("소프트웨어학과")
                     .memberPhoneNumber("01012345678")
@@ -67,7 +67,7 @@ public class DataInitializer implements CommandLineRunner {
 
             Member member2 = Member.builder()
                     .memberEmail("junpark@ajou.ac.kr")
-                    .memberRole("ROLE_USER")
+                    .memberRole("USER_ROLE")
                     .memberName("박준")
                     .memberProvideId("google_test2")
                     .memberMajor("소프트웨어학과")
@@ -79,7 +79,7 @@ public class DataInitializer implements CommandLineRunner {
 
             Member member3 = Member.builder()
                     .memberEmail("jiwon312@ajou.ac.kr")
-                    .memberRole("ROLE_USER")
+                    .memberRole("USER_ROLE")
                     .memberName("김지원")
                     .memberProvideId("google_test3")
                     .memberMajor("디지털미디어학과")
@@ -102,6 +102,8 @@ public class DataInitializer implements CommandLineRunner {
                     .clubGeneration("34")
                     .clubRoom("구학생회관 201호")
                     .clubEstablishmentDate(LocalDate.of(2017, 7, 1))
+                    .clubGroupChatLink("https://open.kakao.com/o/gUEMLKVg")
+                    .clubGroupChatPassword("1234")
                     .build();
             clubRepository.save(club);
 
@@ -137,7 +139,7 @@ public class DataInitializer implements CommandLineRunner {
                     .groupDescription("두잇 가입 그룹")
                     .club(club)
                     .groupType(GroupType.JOIN)
-                    .groupJoinLink("https://woohakdong.com/clubs/doit")
+                    .groupJoinLink("https://www.woohakdong.com/clubs/" + club.getClubEnglishName())
                     .groupChatLink("https://open.kakao.com/o/gUEMLKVg")
                     .groupChatPassword("1234")
                     .groupAmount(10000)

--- a/src/main/java/woohakdong/server/common/exception/CustomErrorInfo.java
+++ b/src/main/java/woohakdong/server/common/exception/CustomErrorInfo.java
@@ -32,6 +32,7 @@ public enum CustomErrorInfo {
     ITEM_HISTORY_NOT_FOUND(400, "item history not found", 400024),
     CLUB_ACCOUNT_NOT_FOUND(400, "club account not found", 400025),
     GET_TRANSACTION_FAILED(400, "get transaction failed", 400026),
+    CLUB_MEMBER_NOT_FOUND(400, "club member not found", 400027),
 
     // 401 UNAUTHORIZED
     INVALID_ACCESS_TOKEN(401, "Invaild access token", 401001),

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
@@ -55,4 +55,8 @@ public class ClubMember {
         this.clubMemberRole = clubMemberRole;
         this.member = member;
     }
+
+    public void changeRole(ClubMemberRole clubMemberRole) {
+        this.clubMemberRole = clubMemberRole;
+    }
 }

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMemberJpaRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMemberJpaRepository.java
@@ -1,5 +1,6 @@
 package woohakdong.server.domain.clubmember;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +19,8 @@ public interface ClubMemberJpaRepository extends JpaRepository<ClubMember, Long>
     List<ClubMember> findByClubAndClubMemberAssignedTerm(Club club, LocalDate assignedTerm);
 
     List<ClubMember> findAllByMember(Member member);
+
+    Optional<ClubMember> findByClubAndMemberAndClubMemberAssignedTerm(Club club, Member member, LocalDate assignedTerm);
+
+    Optional<ClubMember> findByClubAndMember(Club club, Member member);
 }

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepository.java
@@ -2,12 +2,15 @@ package woohakdong.server.domain.clubmember;
 
 import java.time.LocalDate;
 import java.util.List;
-import org.springframework.data.repository.query.Param;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.member.Member;
 
 public interface ClubMemberRepository {
     ClubMember save(ClubMember clubMember);
+
+    ClubMember getById(Long clubMemberId);
+
+    ClubMember getByClubAndMember(Club club, Member member);
 
     List<ClubMember> getAllByMember(Member member);
 
@@ -17,8 +20,7 @@ public interface ClubMemberRepository {
 
     Boolean existsByClubAndMember(Club club, Member member);
 
+    List<ClubMember> getByClubAndAssignedTerm(Club club, LocalDate assignedTerm);
 
-    List<ClubMember> getByClubIdAndAssignedTerm(Club club, LocalDate assignedTerm);
-
-    List<ClubMember> findByClubAndClubMemberAssignedTerm(Club club, LocalDate assignedTerm);
+    ClubMember getByClubAndMemberAndAssignedTerm(Club club, Member member, LocalDate assignedTerm);
 }

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryImpl.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryImpl.java
@@ -1,9 +1,12 @@
 package woohakdong.server.domain.clubmember;
 
+import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_MEMBER_NOT_FOUND;
+
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import woohakdong.server.common.exception.CustomException;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.member.Member;
 
@@ -16,6 +19,18 @@ public class ClubMemberRepositoryImpl implements ClubMemberRepository {
     @Override
     public ClubMember save(ClubMember clubMember) {
         return clubMemberJpaRepository.save(clubMember);
+    }
+
+    @Override
+    public ClubMember getById(Long clubMemberId) {
+        return clubMemberJpaRepository.findById(clubMemberId)
+                .orElseThrow(() -> new CustomException(CLUB_MEMBER_NOT_FOUND));
+    }
+
+    @Override
+    public ClubMember getByClubAndMember(Club club, Member member) {
+        return clubMemberJpaRepository.findByClubAndMember(club, member)
+                .orElseThrow(() -> new CustomException(CLUB_MEMBER_NOT_FOUND));
     }
 
     @Override
@@ -39,12 +54,13 @@ public class ClubMemberRepositoryImpl implements ClubMemberRepository {
     }
 
     @Override
-    public List<ClubMember> getByClubIdAndAssignedTerm(Club club, LocalDate assignedTerm) {
+    public List<ClubMember> getByClubAndAssignedTerm(Club club, LocalDate assignedTerm) {
         return clubMemberJpaRepository.findByClubAndClubMemberAssignedTerm(club, assignedTerm);
     }
 
     @Override
-    public List<ClubMember> findByClubAndClubMemberAssignedTerm(Club club, LocalDate assignedTerm) {
-        return clubMemberJpaRepository.findByClubAndClubMemberAssignedTerm(club, assignedTerm);
+    public ClubMember getByClubAndMemberAndAssignedTerm(Club club, Member member, LocalDate assignedTerm) {
+        return clubMemberJpaRepository.findByClubAndMemberAndClubMemberAssignedTerm(club, member, assignedTerm)
+                .orElseThrow(() -> new CustomException(CLUB_MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRole.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRole.java
@@ -6,8 +6,11 @@ import lombok.RequiredArgsConstructor;
 public enum ClubMemberRole {
 
     PRESIDENT("회장"),
+    VICEPRESIDENT("부회장"),
+    SECRETARY("총무"),
     OFFICER("임원"),
-    MEMBER("회원");
+    MEMBER("회원")
+    ;
 
     private final String role;
 }

--- a/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
@@ -103,7 +103,7 @@ class ClubServiceTest {
         List<Group> groups = groupRepository.getAll();
         assertThat(groups).hasSize(1);
         assertThat(groups.get(0)).extracting("groupName", "groupType", "groupJoinLink")
-                .containsExactly(clubCreateRequest.clubName(), JOIN, "https://woohakdong.com/clubs/Durian");
+                .containsExactly(clubCreateRequest.clubName(), JOIN, "https://www.woohakdong.com/clubs/Durian");
     }
 
     @DisplayName("동아리를 등록하면, 등록한 사람이 회장으로 등록된다.")
@@ -307,7 +307,7 @@ class ClubServiceTest {
                 .club(club)
                 .groupType(JOIN)
                 .groupName(club.getClubName())
-                .groupJoinLink("https://wooahakdong.com/clubs/" + club.getClubEnglishName())
+                .groupJoinLink("https://www.wooahakdong.com/clubs/" + club.getClubEnglishName())
                 .groupAmount(club.getClubDues())
                 .groupChatLink(club.getClubGroupChatLink())
                 .groupChatPassword(club.getClubGroupChatPassword())

--- a/src/test/java/woohakdong/server/api/service/clubMember/ClubMemberServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/clubMember/ClubMemberServiceTest.java
@@ -1,28 +1,36 @@
 package woohakdong.server.api.service.clubMember;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static woohakdong.server.domain.clubmember.ClubMemberRole.MEMBER;
+import static woohakdong.server.domain.clubmember.ClubMemberRole.OFFICER;
+import static woohakdong.server.domain.clubmember.ClubMemberRole.PRESIDENT;
+import static woohakdong.server.domain.clubmember.ClubMemberRole.VICEPRESIDENT;
+
+import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.api.controller.clubMember.dto.ClubMemberInfoResponse;
+import woohakdong.server.common.exception.CustomErrorInfo;
+import woohakdong.server.common.exception.CustomException;
+import woohakdong.server.common.security.jwt.CustomUserDetails;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
 import woohakdong.server.domain.clubmember.ClubMember;
 import woohakdong.server.domain.clubmember.ClubMemberRepository;
+import woohakdong.server.domain.clubmember.ClubMemberRole;
 import woohakdong.server.domain.member.Member;
 import woohakdong.server.domain.member.MemberRepository;
 import woohakdong.server.domain.school.School;
 import woohakdong.server.domain.school.SchoolRepository;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static woohakdong.server.domain.clubmember.ClubMemberRole.MEMBER;
-import static woohakdong.server.domain.clubmember.ClubMemberRole.OFFICER;
-
-import java.time.LocalDate;
-import java.util.List;
 
 
 @ActiveProfiles("test")
@@ -49,124 +57,174 @@ class ClubMemberServiceTest {
     @Test
     void getMembers() {
         // given
-        School school = School.builder()
-                .schoolDomain("ajou.ac.kr")
-                .schoolName("아주대학교")
-                .build();
-        schoolRepository.save(school);
+        School school = createSchool("ajou.ac.kr");
+        Club club = createClub(school);
+        Member member1 = createMember(school, "testProvideId2", "박상준", "sangjun@ajou.ac.kr");
+        Member member2 = createMember(school, "testProvideId3", "준상박", "junsang@ajou.ac.kr");
 
-        Club club = Club.builder()
-                .clubName("테스트동아리")
-                .clubEnglishName("testClub")
-                .clubGroupChatLink("https://club-group-chat-link.com")
-                .school(school)
-                .build();
-        clubRepository.save(club);
-
-        Member member1 = Member.builder()
-                .memberProvideId("testProvideId")
-                .memberName("일반 회원 이름")
-                .memberEmail("user@ajou.ac.kr")
-                .school(school)
-                .build();
-
-        Member member2 = Member.builder()
-                .memberProvideId("testProvideId2")
-                .memberName("회장 회원 이름")
-                .memberEmail("president@ajou.ac.kr")
-                .school(school)
-                .build();
-        memberRepository.save(member1);
-        memberRepository.save(member2);
-
-        ClubMember clubMember1 = ClubMember.builder()
-                .clubMemberAssignedTerm(getAssignedTerm())
-                .club(club)
-                .member(member1)
-                .clubMemberRole(MEMBER)
-                .build();
-
-        ClubMember clubMember2 = ClubMember.builder()
-                .clubMemberAssignedTerm(getAssignedTerm())
-                .club(club)
-                .member(member2)
-                .clubMemberRole(OFFICER)
-                .build();
-        clubMemberRepository.save(clubMember1);
-        clubMemberRepository.save(clubMember2);
+        LocalDate now = LocalDate.of(2024, 11, 2);
+        createClubMember(club, member1, MEMBER, getAssignedTerm(now));
+        createClubMember(club, member2, OFFICER, getAssignedTerm(now));
 
         // when
         List<ClubMemberInfoResponse> responses = clubMemberService.getMembers(club.getClubId());
 
-        System.out.println(responses);
-
         // then
-        assertThat(responses).isNotNull();
-        assertThat(responses.size()).isEqualTo(2);
+        assertThat(responses).hasSize(2)
+                .extracting("memberName", "clubMemberRole")
+                .containsExactlyInAnyOrder(
+                        tuple("박상준", MEMBER),
+                        tuple("준상박", OFFICER)
+                );
     }
 
     @DisplayName("분기별 동아리 멤버 리스트를 확인할 수 있다.")
     @Test
     void getTermMembers() {
         // given
+        School school = createSchool("ajou.ac.kr");
+        Club club = createClub(school);
+        Member member1 = createMember(school, "testProvideId2", "박상준", "sangjun@ajou.ac.kr");
+        Member member2 = createMember(school, "testProvideId3", "준상박", "junsang@ajou.ac.kr");
+        Member member3 = createMember(school, "testProvideId4", "김상박", "kimsang@ajou.ac.kr");
+
+        createClubMember(club, member1, MEMBER, LocalDate.of(2024, 1, 1));
+        createClubMember(club, member2, OFFICER, LocalDate.of(2024, 2, 1));
+        createClubMember(club, member3, MEMBER, LocalDate.of(2024, 6, 30));
+        createClubMember(club, member3, OFFICER, LocalDate.of(2024, 7, 1));
+
+        // when
+        List<ClubMemberInfoResponse> responses = clubMemberService.getTermMembers(club.getClubId(),
+                LocalDate.of(2024, 1, 1));
+
+        // then
+        assertThat(responses).hasSize(3)
+                .extracting("memberName", "clubMemberRole")
+                .containsExactlyInAnyOrder(
+                        tuple("박상준", MEMBER),
+                        tuple("준상박", OFFICER),
+                        tuple("김상박", MEMBER)
+                );
+    }
+
+    @DisplayName("동아리 내 나의 정보를 확인할 수 있다.")
+    @Test
+    void getMyInfo() {
+        // Given
+        Member member = setUpMemberSession("박상준");
+        School school = createSchool("ajou.ac.kr");
+        Club club = createClub(school);
+        createClubMember(club, member, MEMBER, LocalDate.now());
+
+        // When
+        ClubMemberInfoResponse response = clubMemberService.getMyInfo(club.getClubId());
+
+        // Then
+        assertThat(response)
+                .extracting("memberName", "clubMemberRole")
+                .containsExactly("박상준", MEMBER);
+    }
+
+    @DisplayName("동아리 회장이라면, 멤버의 역할을 변경할 수 있다.")
+    @Test
+    void changeClubMemberRole() {
+        // Given
+        Member member = setUpMemberSession("박상준");
+        School school = createSchool("ajou.ac.kr");
+        Club club = createClub(school);
+        createClubMember(club, member, PRESIDENT, LocalDate.now());
+
+        Member member2 = createMember(school, "testProvideId2", "김상준", "kimsang@ajou.ac.kr");
+        ClubMember clubMember2 = createClubMember(club, member2, MEMBER, LocalDate.now());
+
+        // When
+        clubMemberService.changeClubMemberRole(club.getClubId(), clubMember2.getClubMemberId(), OFFICER);
+
+        // Then
+        ClubMember savedClubMember = clubMemberRepository.getByClubAndMember(club, member2);
+        assertThat(savedClubMember)
+                .extracting("member.memberName", "clubMemberRole")
+                .containsExactly("김상준", OFFICER);
+    }
+
+    @DisplayName("동아리 회장이 아니라면, 멤버의 역할을 변경할 수 없다.")
+    @Test
+    void changeClubMemberRoleWithOutPRESIDENTRole() {
+        // Given
+        Member member = setUpMemberSession("박상준");
+        School school = createSchool("ajou.ac.kr");
+        Club club = createClub(school);
+        createClubMember(club, member, VICEPRESIDENT, LocalDate.now());
+
+        Member member2 = createMember(school, "testProvideId2", "김상준", "kimsang@ajou.ac.kr");
+        ClubMember clubMember2 = createClubMember(club, member2, MEMBER, LocalDate.now());
+
+        // When & Then
+        assertThatThrownBy(
+                () -> clubMemberService.changeClubMemberRole(club.getClubId(), clubMember2.getClubMemberId(), OFFICER))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(CustomErrorInfo.CLUB_MEMBER_ROLE_NOT_ALLOWED.getMessage());
+    }
+
+    private School createSchool(String domain) {
         School school = School.builder()
-                .schoolDomain("ajou.ac.kr")
+                .schoolDomain(domain)
                 .schoolName("아주대학교")
                 .build();
-        schoolRepository.save(school);
+        return schoolRepository.save(school);
+    }
 
+    private Club createClub(School school) {
         Club club = Club.builder()
-                .clubName("테스트동아리")
+                .clubName("테스트 동아리")
                 .clubEnglishName("testClub")
                 .clubGroupChatLink("https://club-group-chat-link.com")
                 .school(school)
                 .build();
-        clubRepository.save(club);
-
-        Member member1 = Member.builder()
-                .memberProvideId("testProvideId")
-                .memberName("일반 회원 이름")
-                .memberEmail("user@ajou.ac.kr")
-                .school(school)
-                .build();
-
-        Member member2 = Member.builder()
-                .memberProvideId("testProvideId2")
-                .memberName("회장 회원 이름")
-                .memberEmail("president@ajou.ac.kr")
-                .school(school)
-                .build();
-        memberRepository.save(member1);
-        memberRepository.save(member2);
-
-        ClubMember clubMember1 = ClubMember.builder()
-                .clubMemberAssignedTerm(getAssignedTerm())
-                .club(club)
-                .member(member1)
-                .clubMemberRole(MEMBER)
-                .build();
-
-        ClubMember clubMember2 = ClubMember.builder()
-                .clubMemberAssignedTerm(getAssignedTerm())
-                .club(club)
-                .member(member2)
-                .clubMemberRole(OFFICER)
-                .build();
-        clubMemberRepository.save(clubMember1);
-        clubMemberRepository.save(clubMember2);
-
-        // when
-        List<ClubMemberInfoResponse> responses = clubMemberService.getTermMembers(club.getClubId(), getAssignedTerm());
-
-        // then
-        assertThat(responses).isNotNull();
-        assertThat(responses.size()).isEqualTo(2);
+        return clubRepository.save(club);
     }
 
-    private LocalDate getAssignedTerm() {
-        LocalDate now = LocalDate.now();
-        int year = now.getYear();
-        int semester = now.getMonthValue() <= 6 ? 1 : 7; // 1: 1학기, 7: 2학기
+    private Member createMember(School school, String provideId, String name, String email) {
+        Member member = Member.builder()
+                .memberProvideId(provideId)
+                .memberName(name)
+                .memberEmail(email)
+                .school(school)
+                .build();
+        return memberRepository.save(member);
+    }
+
+    private ClubMember createClubMember(Club club, Member member, ClubMemberRole memberRole, LocalDate assignedTerm) {
+        ClubMember clubMember = ClubMember.builder()
+                .clubMemberAssignedTerm(getAssignedTerm(assignedTerm))
+                .club(club)
+                .member(member)
+                .clubMemberRole(memberRole)
+                .build();
+        return clubMemberRepository.save(clubMember);
+    }
+
+    private LocalDate getAssignedTerm(LocalDate date) {
+        int year = date.getYear();
+        int semester = date.getMonthValue() <= 6 ? 1 : 7; // 1: 1학기, 7: 2학기
         return LocalDate.of(year, semester, 1);
+    }
+
+    private Member setUpMemberSession(String name) {
+        String provideId = "testProvideId";
+        Member member = Member.builder()
+                .memberProvideId(provideId)
+                .memberName(name)
+                .memberEmail("john.doe@example.com")
+                .build();
+        memberRepository.save(member);
+
+        String role = "USER_ROLE";
+        CustomUserDetails customUserDetails = new CustomUserDetails(provideId, role);
+        UsernamePasswordAuthenticationToken authToken =
+                new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        return member;
     }
 }


### PR DESCRIPTION
### 기능 설명
- 동아리 회장은 동아리 멤버의 role을 변경할 수 있다.

### 작성 상세 내용
- 동아리 내 본인 역할 불러오기 api 구현 [ `GET` /v1/clubs/{clubId}/members/me ]
- 동아리 멤버 역할 변경 api 구현 [ `PUT` /v1/clubs/{clubId}/members/{clubMemberId}/role ]
- 동아리 멤버 정보 불러오기 api 스펙 중 학교 정보 제거 [ `GET` /v1/clubs/{clubId}/members ]
- 테스트 코드 작성 및 리팩토링

### 관련 지라 티켓 번호
[WHD-130]


[WHD-130]: https://8901dev.atlassian.net/browse/WHD-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ