### PR TITLE
[WHD-227] Feat: payment transfer link logic

### DIFF
--- a/src/main/java/woohakdong/server/api/service/bank/MockBankService.java
+++ b/src/main/java/woohakdong/server/api/service/bank/MockBankService.java
@@ -60,16 +60,16 @@ public class MockBankService implements BankService {
     private static final String NH_TRANSACTIONS_API_URL = "https://developers.nonghyup.com/InquireTransactionHistory.nh";
 
     static {
-        Map<String, String> kbBank = new HashMap<>();
-        kbBank.put("1234567890", "PIN-1234567890"); // 계좌번호, PIN
-        kbBank.put("1111111111", "PIN-1111111111");
+        Map<String, String> nhBank = new HashMap<>();
+        nhBank.put("3020000011529", "PIN-1234567890"); // 계좌번호, PIN
+        nhBank.put("3020000011656", "PIN-1111111111");
 
-        Map<String, String> shinhanBank = new HashMap<>();
-        shinhanBank.put("2222222222", "PIN-2222222222");
-        shinhanBank.put("3333333333", "PIN-3333333333");
+        Map<String, String> kdbBank = new HashMap<>();
+        kdbBank.put("1000003202002", "PIN-2222222222");
+        kdbBank.put("1000003141002", "PIN-3333333333");
 
-        certifiedBanks.put("국민은행", kbBank);
-        certifiedBanks.put("신한은행", shinhanBank);
+        certifiedBanks.put("농협은행", nhBank);
+        certifiedBanks.put("산업은행", kdbBank);
     }
 
     public ClubAccountValidateResponse certifyAccount(ClubAccountValidateRequest clubAccountValidateRequest) {

--- a/src/main/java/woohakdong/server/api/service/bank/MockBankService.java
+++ b/src/main/java/woohakdong/server/api/service/bank/MockBankService.java
@@ -60,6 +60,14 @@ public class MockBankService implements BankService {
     private static final String NH_TRANSACTIONS_API_URL = "https://developers.nonghyup.com/InquireTransactionHistory.nh";
 
     static {
+        Map<String, String> kbBank = new HashMap<>();
+        kbBank.put("1234567890", "PIN-1234567890"); // 계좌번호, PIN
+        kbBank.put("1111111111", "PIN-1111111111");
+
+        Map<String, String> shinhanBank = new HashMap<>();
+        shinhanBank.put("2222222222", "PIN-2222222222");
+        shinhanBank.put("3333333333", "PIN-3333333333");
+
         Map<String, String> nhBank = new HashMap<>();
         nhBank.put("3020000011529", "PIN-1234567890"); // 계좌번호, PIN
         nhBank.put("3020000011656", "PIN-1111111111");
@@ -68,6 +76,8 @@ public class MockBankService implements BankService {
         kdbBank.put("1000003202002", "PIN-2222222222");
         kdbBank.put("1000003141002", "PIN-3333333333");
 
+        certifiedBanks.put("국민은행", kbBank);
+        certifiedBanks.put("신한은행", shinhanBank);
         certifiedBanks.put("농협은행", nhBank);
         certifiedBanks.put("산업은행", kdbBank);
     }

--- a/src/main/java/woohakdong/server/domain/group/Group.java
+++ b/src/main/java/woohakdong/server/domain/group/Group.java
@@ -36,7 +36,7 @@ public class Group {
 
     private String groupDescription;
 
-    private int groupAmount;
+    private Integer groupAmount;
 
     @Column(nullable = false)
     private String groupJoinLink;


### PR DESCRIPTION
### 기능 설명

- 결제 후 이체하는 로직

### 작성 상세 내용

- 결제 완료 api 호출 시 해당 동아리 계좌로 이체
- webhook 요청 시 해당 동아리 계좌로 이체
- 은행 정보 변경

### 관련 지라 티켓 번호
[WHD-227](https://8901dev.atlassian.net/jira/software/projects/WHD/boards/1?selectedIssue=WHD-226)
### 참고 자료


[WHD-227]: https://8901dev.atlassian.net/browse/WHD-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ