### PR TITLE
[WHD-236]: Add BaseEntity for common timestamp fields

### DIFF
--- a/src/main/java/woohakdong/server/common/config/JpaAuditingConfig.java
+++ b/src/main/java/woohakdong/server/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package woohakdong.server.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/woohakdong/server/domain/BaseEntity.java
+++ b/src/main/java/woohakdong/server/domain/BaseEntity.java
@@ -1,0 +1,23 @@
+package woohakdong.server.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    protected LocalDateTime modifiedAt;
+}

--- a/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistory.java
+++ b/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistory.java
@@ -13,13 +13,15 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.item.Item;
 import woohakdong.server.domain.member.Member;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ItemHistory {
+public class ItemHistory extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long itemHistoryId;

--- a/src/main/java/woohakdong/server/domain/admin/adminAccount/AdminAccount.java
+++ b/src/main/java/woohakdong/server/domain/admin/adminAccount/AdminAccount.java
@@ -12,12 +12,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.admin.adminAccountHistory.AdminAccountHistory;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class AdminAccount {
+public class AdminAccount extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long adminAccountId;

--- a/src/main/java/woohakdong/server/domain/admin/adminAccountHistory/AdminAccountHistory.java
+++ b/src/main/java/woohakdong/server/domain/admin/adminAccountHistory/AdminAccountHistory.java
@@ -1,20 +1,29 @@
 package woohakdong.server.domain.admin.adminAccountHistory;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.admin.adminAccount.AccountType;
 import woohakdong.server.domain.admin.adminAccount.AdminAccount;
-import woohakdong.server.domain.clubAccount.ClubAccount;
-
-import java.time.LocalDate;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class AdminAccountHistory {
+public class AdminAccountHistory extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long adminAccountHistoryId;
@@ -41,8 +50,8 @@ public class AdminAccountHistory {
 
     @Builder
     private AdminAccountHistory(AccountType adminAccountHistoryInOutType, LocalDate adminAccountHistoryTranDate,
-                               Long adminAccountHistoryBalanceAmount, Long adminAccountHistoryTranAmount,
-                               String adminAccountHistoryContent, AdminAccount adminAccount) {
+                                Long adminAccountHistoryBalanceAmount, Long adminAccountHistoryTranAmount,
+                                String adminAccountHistoryContent, AdminAccount adminAccount) {
         this.adminAccountHistoryInOutType = adminAccountHistoryInOutType;
         this.adminAccountHistoryTranDate = adminAccountHistoryTranDate;
         this.adminAccountHistoryBalanceAmount = adminAccountHistoryBalanceAmount;

--- a/src/main/java/woohakdong/server/domain/club/Club.java
+++ b/src/main/java/woohakdong/server/domain/club/Club.java
@@ -16,6 +16,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.clubHistory.ClubHistory;
 import woohakdong.server.domain.clubmember.ClubMember;
 import woohakdong.server.domain.group.Group;
@@ -25,7 +26,7 @@ import woohakdong.server.domain.school.School;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Club {
+public class Club extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/woohakdong/server/domain/clubAccount/ClubAccount.java
+++ b/src/main/java/woohakdong/server/domain/clubAccount/ClubAccount.java
@@ -1,21 +1,29 @@
 package woohakdong.server.domain.clubAccount;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.clubAccountHistory.ClubAccountHistory;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ClubAccount {
+public class ClubAccount extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistory.java
+++ b/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistory.java
@@ -1,21 +1,30 @@
 package woohakdong.server.domain.clubAccountHistory;
 
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.admin.adminAccount.AccountType;
 import woohakdong.server.domain.clubAccount.ClubAccount;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ClubAccountHistory {
+public class ClubAccountHistory extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long clubAccountHistoryId;

--- a/src/main/java/woohakdong/server/domain/clubHistory/ClubHistory.java
+++ b/src/main/java/woohakdong/server/domain/clubHistory/ClubHistory.java
@@ -1,18 +1,25 @@
 package woohakdong.server.domain.clubHistory;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.club.Club;
 
-import java.time.LocalDate;
-
 @Entity
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ClubHistory {
+@Getter
+public class ClubHistory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
@@ -15,13 +15,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.member.Member;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class ClubMember {
+public class ClubMember extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/woohakdong/server/domain/group/Group.java
+++ b/src/main/java/woohakdong/server/domain/group/Group.java
@@ -18,6 +18,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.order.Order;
 
@@ -25,7 +26,7 @@ import woohakdong.server.domain.order.Order;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "\"group\"")
-public class Group {
+public class Group extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/woohakdong/server/domain/item/Item.java
+++ b/src/main/java/woohakdong/server/domain/item/Item.java
@@ -1,20 +1,32 @@
 package woohakdong.server.domain.item;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.ItemHistory.ItemHistory;
 import woohakdong.server.domain.club.Club;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Item {
+public class Item extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long itemId;
@@ -53,8 +65,8 @@ public class Item {
 
     @Builder
     private Item(Club club, LocalDateTime itemRentalDate, Integer itemRentalTime, String itemLocation,
-                ItemCategory itemCategory, Integer itemRentalMaxDay, Boolean itemAvailable,
-                Boolean itemUsing, String itemDescription, String itemPhoto, String itemName) {
+                 ItemCategory itemCategory, Integer itemRentalMaxDay, Boolean itemAvailable,
+                 Boolean itemUsing, String itemDescription, String itemPhoto, String itemName) {
         this.club = club;
         this.itemRentalDate = itemRentalDate;
         this.itemRentalTime = itemRentalTime;

--- a/src/main/java/woohakdong/server/domain/itemBorrowed/ItemBorrowed.java
+++ b/src/main/java/woohakdong/server/domain/itemBorrowed/ItemBorrowed.java
@@ -1,20 +1,26 @@
 package woohakdong.server.domain.itemBorrowed;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.clubmember.ClubMember;
 import woohakdong.server.domain.item.Item;
-
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class ItemBorrowed {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long itemBorrowedId;
@@ -36,12 +42,12 @@ public class ItemBorrowed {
         this.itemBorrowedReturnDate = itemBorrowedReturnDate;
     }
 
-    public static ItemBorrowed createItemBorrowed(ClubMember clubMember, Item item, LocalDateTime itemBorrowedReturnDate) {
-        ItemBorrowed itemBorrowed = ItemBorrowed.builder()
+    public static ItemBorrowed createItemBorrowed(ClubMember clubMember, Item item,
+                                                  LocalDateTime itemBorrowedReturnDate) {
+        return ItemBorrowed.builder()
                 .itemBorrowedReturnDate(itemBorrowedReturnDate)
                 .clubMember(clubMember)
                 .item(item)
                 .build();
-        return itemBorrowed;
     }
 }

--- a/src/main/java/woohakdong/server/domain/member/Member.java
+++ b/src/main/java/woohakdong/server/domain/member/Member.java
@@ -1,14 +1,27 @@
 package woohakdong.server.domain.member;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.school.School;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Member {
+public class Member extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
@@ -35,10 +48,10 @@ public class Member {
     @JoinColumn(name = "school_id")
     private School school;
 
-    protected Member() {}
-
     @Builder
-    private Member(String memberProvideId, String memberName, String memberEmail, String memberRole, School school, String memberPhoneNumber, String memberMajor, String memberStudentNumber, MemberGender memberGender, String memberPassword) {
+    private Member(String memberProvideId, String memberName, String memberEmail, String memberRole, School school,
+                   String memberPhoneNumber, String memberMajor, String memberStudentNumber, MemberGender memberGender,
+                   String memberPassword) {
         this.memberProvideId = memberProvideId;
         this.memberName = memberName;
         this.memberEmail = memberEmail;

--- a/src/main/java/woohakdong/server/domain/order/Order.java
+++ b/src/main/java/woohakdong/server/domain/order/Order.java
@@ -20,6 +20,7 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.group.Group;
 import woohakdong.server.domain.member.Member;
 import woohakdong.server.domain.payment.Payment;
@@ -28,7 +29,7 @@ import woohakdong.server.domain.payment.Payment;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Getter
 @Table(name = "\"order\"")
-public class Order {
+public class Order extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/woohakdong/server/domain/payment/Payment.java
+++ b/src/main/java/woohakdong/server/domain/payment/Payment.java
@@ -11,11 +11,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Payment {
+public class Payment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,7 +35,8 @@ public class Payment {
     private Integer paymentAmount;
 
     @Builder
-    private Payment(Integer paymentAmount, String paymentImpUid, String paymentMerchantUid, PaymentStatus paymentStatus) {
+    private Payment(Integer paymentAmount, String paymentImpUid, String paymentMerchantUid,
+                    PaymentStatus paymentStatus) {
         this.paymentAmount = paymentAmount;
         this.paymentImpUid = paymentImpUid;
         this.paymentMerchantUid = paymentMerchantUid;

--- a/src/main/java/woohakdong/server/domain/refreshToken/RefreshToken.java
+++ b/src/main/java/woohakdong/server/domain/refreshToken/RefreshToken.java
@@ -4,13 +4,15 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Setter
 public class RefreshToken {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -19,8 +21,6 @@ public class RefreshToken {
     private String refreshProvideId;
     private String refresh;
     private String RefreshExpiration;
-
-    protected RefreshToken() {}
 
     @Builder
     public RefreshToken(String refreshProvideId, String refresh, String refreshExpiration) {

--- a/src/main/java/woohakdong/server/domain/schedule/Schedule.java
+++ b/src/main/java/woohakdong/server/domain/schedule/Schedule.java
@@ -2,6 +2,7 @@ package woohakdong.server.domain.schedule;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,13 +14,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.club.Club;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "\"schedule\"")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Schedule {
+public class Schedule extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,7 +36,7 @@ public class Schedule {
 
     private String scheduleColor;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_id")
     private Club club;
 

--- a/src/main/java/woohakdong/server/domain/school/School.java
+++ b/src/main/java/woohakdong/server/domain/school/School.java
@@ -1,20 +1,25 @@
 package woohakdong.server.domain.school;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
+import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.member.Member;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Setter
-public class School {
+public class School extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long schoolId;
@@ -27,8 +32,6 @@ public class School {
 
     @OneToMany(mappedBy = "school")
     private List<Club> clubs = new ArrayList<>();
-
-    protected School() {}
 
     @Builder
     public School(String schoolName, String schoolDomain) {


### PR DESCRIPTION
### 기능 설명
- 모든 Entity가 createdAt, modifiedAt 필드를 갖는 BaseEntity를 상속 받도록 수정

### 작성 상세 내용
- 이제 모든 Entity의 생성일, 수정일 시간을 추적할 수 있다.

### 관련 지라 티켓 번호
[WHD-236]

### 참고 자료


[WHD-236]: https://8901dev.atlassian.net/browse/WHD-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ