### PR TITLE
[WHD-239] Feat: Search clubMembers with keyword

### DIFF
--- a/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberController.java
+++ b/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberController.java
@@ -21,16 +21,10 @@ public class ClubMemberController implements ClubMemberControllerDocs {
     private final ClubMemberService clubMemberService;
 
     @GetMapping("/{clubId}/members")
-    public ListWrapperResponse<ClubMemberInfoResponse> getTermMembers(@PathVariable Long clubId,
-                                                                      @RequestParam(required = false) LocalDate clubMemberAssignedTerm) {
-
-        if (clubMemberAssignedTerm != null) {
-            // 학기로 필터링된 멤버 목록 조회
-            return ListWrapperResponse.of(clubMemberService.getTermMembers(clubId, clubMemberAssignedTerm));
-        } else {
-            // 모든 멤버 조회
-            return ListWrapperResponse.of(clubMemberService.getMembers(clubId));
-        }
+    public ListWrapperResponse<ClubMemberInfoResponse> getFilteredMembers(@PathVariable Long clubId,
+                                                                          @RequestParam(required = false) LocalDate clubMemberAssignedTerm,
+                                                                          @RequestParam(required = false) String name){
+            return ListWrapperResponse.of(clubMemberService.getFilteredMembers(clubId, name, clubMemberAssignedTerm));
     }
 
     @GetMapping("/{clubId}/members/{clubMemberId}")

--- a/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberControllerDocs.java
+++ b/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberControllerDocs.java
@@ -4,13 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import woohakdong.server.api.controller.ListWrapperResponse;
 import woohakdong.server.api.controller.clubMember.dto.ClubMemberInfoResponse;
 
 import java.time.LocalDate;
-import java.util.List;
 import woohakdong.server.domain.clubmember.ClubMemberRole;
 
 @Tag(name = "Club Member", description = "동아리 멤버 관련 API")
@@ -20,20 +17,20 @@ public interface ClubMemberControllerDocs {
     @Operation(summary = "동아리 소속 기수별 멤버 리스트 조회하기", description = "clubId와 기수(24-1)로 동아리 소속 기수별 멤버 리스트 조회하기 쿼리 파리미터가 없다면 현재 기수 조회")
     @ApiResponse(responseCode = "200", description = "동아리 소속 기수별 멤버 리스트 조회하기 성공", useReturnTypeSchema = true)
     @ApiResponse(responseCode = "400", description = "동아리 소속 기수별 멤버 리스트 조회하기 실패")
-    public ListWrapperResponse<ClubMemberInfoResponse> getTermMembers(@PathVariable Long clubId, @PathVariable LocalDate clubMemberAssignedTerm);
+    public ListWrapperResponse<ClubMemberInfoResponse> getFilteredMembers(Long clubId, LocalDate clubMemberAssignedTerm, String name);
 
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "동아리 내 나의 정보 불러오기", description = "동아리 내 정보인 Role과 clubMemberId를 불러온다.")
     @ApiResponse(responseCode = "200", description = "동아리 내 나의 정보 불러오기 성공", useReturnTypeSchema = true)
-    public ClubMemberInfoResponse getMyInfo(@PathVariable Long clubId);
+    public ClubMemberInfoResponse getMyInfo(Long clubId);
 
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "동아리 멤버의 역할 변경하기", description = "동아리 멤버의 Role을 변경한다.")
     @ApiResponse(responseCode = "200", description = "동아리 멤버의 역할 변경하기 성공", useReturnTypeSchema = true)
-    public void changeRole(@PathVariable Long clubId, @PathVariable Long clubMemberId, @RequestParam ClubMemberRole clubMemberRole);
+    public void changeRole(Long clubId, Long clubMemberId, ClubMemberRole clubMemberRole);
 
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "동아리 멤버 상세 정보 불러오기", description = "동아리 clubMemberId로 상세 정보를 불러온다.")
     @ApiResponse(responseCode = "200", description = "동아리 멤버 상세 정보 불러오기 성공", useReturnTypeSchema = true)
-    public ClubMemberInfoResponse getClubMemberInfo(@PathVariable Long clubId, @PathVariable Long clubMemberId);
+    public ClubMemberInfoResponse getClubMemberInfo(Long clubId, Long clubMemberId);
 }

--- a/src/main/java/woohakdong/server/api/controller/clubMember/dto/ClubMemberInfoResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/clubMember/dto/ClubMemberInfoResponse.java
@@ -22,7 +22,8 @@ public record ClubMemberInfoResponse(
         LocalDate clubJoinedDate,
         LocalDate clubMemberAssignedTerm
 ) {
-    public static ClubMemberInfoResponse from(Member member, ClubMember clubMember) {
+    public static ClubMemberInfoResponse from(ClubMember clubMember) {
+        Member member = clubMember.getMember();
         return ClubMemberInfoResponse.builder()
                 .memberId(member.getMemberId())
                 .memberName(member.getMemberName())

--- a/src/main/java/woohakdong/server/api/service/clubMember/ClubMemberService.java
+++ b/src/main/java/woohakdong/server/api/service/clubMember/ClubMemberService.java
@@ -34,28 +34,18 @@ public class ClubMemberService {
         Club club = clubRepository.getById(clubId);
         LocalDate assignedTerm = getAssignedTerm();
 
-        List<ClubMember> clubMembers = clubMemberRepository.getByClubAndAssignedTerm(club, assignedTerm);
+        List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null, assignedTerm);
 
         return clubMembers.stream()
-                .map(clubMember -> ClubMemberInfoResponse.from(clubMember.getMember(), clubMember))
-                .toList();
-    }
-
-    public List<ClubMemberInfoResponse> getTermMembers(Long clubId, LocalDate clubMemberAssignedTerm) {
-        Club club = clubRepository.getById(clubId);
-        List<ClubMember> clubMembers = clubMemberRepository.getByClubAndAssignedTerm(club, clubMemberAssignedTerm);
-
-        return clubMembers.stream()
-                .map(clubMember -> ClubMemberInfoResponse.from(clubMember.getMember(), clubMember))
+                .map(ClubMemberInfoResponse::from)
                 .toList();
     }
 
     public ClubMemberInfoResponse getClubMemberInfo(Long clubId, Long clubMemberId) {
         Club club = clubRepository.getById(clubId);
-
         ClubMember clubMember = clubMemberRepository.getById(clubMemberId);
 
-        return ClubMemberInfoResponse.from(clubMember.getMember(), clubMember);
+        return ClubMemberInfoResponse.from(clubMember);
     }
 
     public ClubMemberInfoResponse getMyInfo(Long clubId) {
@@ -65,7 +55,7 @@ public class ClubMemberService {
 
         ClubMember clubMember = clubMemberRepository.getByClubAndMemberAndAssignedTerm(club, member, assignedTerm);
 
-        return ClubMemberInfoResponse.from(clubMember.getMember(), clubMember);
+        return ClubMemberInfoResponse.from(clubMember);
     }
 
     @Transactional
@@ -80,6 +70,16 @@ public class ClubMemberService {
 
         ClubMember clubMember = clubMemberRepository.getById(clubMemberId);
         clubMember.changeRole(clubMemberRole);
+    }
+
+    public List<ClubMemberInfoResponse> getFilteredMembers(Long clubId, String name, LocalDate assignedTerm) {
+        assignedTerm = assignedTerm == null ? getAssignedTerm() : assignedTerm;
+        Club club = clubRepository.getById(clubId);
+        List<ClubMember> clubMemberList = clubMemberRepository.getAllBySearchFilter(club, name, assignedTerm);
+
+        return clubMemberList.stream()
+                .map(ClubMemberInfoResponse::from)
+                .toList();
     }
 
     private LocalDate getAssignedTerm() {

--- a/src/main/java/woohakdong/server/api/service/notification/NotificationService.java
+++ b/src/main/java/woohakdong/server/api/service/notification/NotificationService.java
@@ -39,7 +39,7 @@ public class NotificationService {
     public void sendNotificationWithClubInfoUpdate(Long clubId, LocalDate assignedTerm) {
         getMemberFromJwtInformation(); // TODO : 임원 체크
         Club club = clubRepository.getById(clubId);
-        List<ClubMember> clubMembers = clubMemberRepository.getByClubAndAssignedTerm(club, assignedTerm);
+        List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null, assignedTerm);
 
         clubMembers.stream()
                 .map(ClubMember::getMember)
@@ -56,7 +56,7 @@ public class NotificationService {
     public void sendNotificationWithSchedule(Long clubId, Long scheduleId, LocalDate assignedTerm) {
         getMemberFromJwtInformation(); // TODO : 임원 체크
         Club club = clubRepository.getById(clubId);
-        List<ClubMember> clubMembers = clubMemberRepository.getByClubAndAssignedTerm(club, assignedTerm);
+        List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null, assignedTerm);
         Schedule schedule = scheduleRepository.getById(scheduleId);
         String scheduleDate = schedule.getScheduleDateTime().format(YEAR_MONTH_DAY_HOUR);
 

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMemberJpaRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMemberJpaRepository.java
@@ -23,4 +23,6 @@ public interface ClubMemberJpaRepository extends JpaRepository<ClubMember, Long>
     Optional<ClubMember> findByClubAndMemberAndClubMemberAssignedTerm(Club club, Member member, LocalDate assignedTerm);
 
     Optional<ClubMember> findByClubAndMember(Club club, Member member);
+
+    List<ClubMember> findByClubAndClubMemberAssignedTermAndMemberMemberNameContaining(Club club, LocalDate assignedTerm, String name);
 }

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepository.java
@@ -20,7 +20,7 @@ public interface ClubMemberRepository {
 
     Boolean existsByClubAndMember(Club club, Member member);
 
-    List<ClubMember> getByClubAndAssignedTerm(Club club, LocalDate assignedTerm);
-
     ClubMember getByClubAndMemberAndAssignedTerm(Club club, Member member, LocalDate assignedTerm);
+
+    List<ClubMember> getAllBySearchFilter(Club club, String name, LocalDate assignedTerm);
 }

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryImpl.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryImpl.java
@@ -54,13 +54,18 @@ public class ClubMemberRepositoryImpl implements ClubMemberRepository {
     }
 
     @Override
-    public List<ClubMember> getByClubAndAssignedTerm(Club club, LocalDate assignedTerm) {
-        return clubMemberJpaRepository.findByClubAndClubMemberAssignedTerm(club, assignedTerm);
-    }
-
-    @Override
     public ClubMember getByClubAndMemberAndAssignedTerm(Club club, Member member, LocalDate assignedTerm) {
         return clubMemberJpaRepository.findByClubAndMemberAndClubMemberAssignedTerm(club, member, assignedTerm)
                 .orElseThrow(() -> new CustomException(CLUB_MEMBER_NOT_FOUND));
+    }
+
+    @Override
+    public List<ClubMember> getAllBySearchFilter(Club club, String name, LocalDate assignedTerm) {
+        if (name == null || name.isBlank()) {
+            return clubMemberJpaRepository.findByClubAndClubMemberAssignedTerm(club, assignedTerm);
+        }
+
+        return clubMemberJpaRepository.findByClubAndClubMemberAssignedTermAndMemberMemberNameContaining(club,
+                assignedTerm, name);
     }
 }


### PR DESCRIPTION
### 기능 설명
검색어로 분기별 동아리 회원 조회 가능

### 작성 상세 내용
- 멤버 이름이 존재하지 않는다면, 해당 분기의 모든 멤버를 조회한다.
- QueryParameter의 유무에 따라 호출할 메소드를 결정할 책임을 Repository 단으로 전달

### 관련 지라 티켓 번호
[WHD-239]

### 참고 자료


[WHD-239]: https://8901dev.atlassian.net/browse/WHD-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ