### PR TITLE
[WHD-251] Feat: item filter list api

### DIFF
--- a/src/main/java/woohakdong/server/api/controller/item/ItemController.java
+++ b/src/main/java/woohakdong/server/api/controller/item/ItemController.java
@@ -27,7 +27,7 @@ public class ItemController implements ItemControllerDocs {
     }
 
     @GetMapping("/{clubId}/items/{itemId}")
-    public ItemResponse getItemInfo(@PathVariable Long clubId, @PathVariable Long itemId) {
+    public ItemInfoResponse getItemInfo(@PathVariable Long clubId, @PathVariable Long itemId) {
         return itemService.getItemInfo(clubId, itemId);
     }
 

--- a/src/main/java/woohakdong/server/api/controller/item/ItemController.java
+++ b/src/main/java/woohakdong/server/api/controller/item/ItemController.java
@@ -22,8 +22,10 @@ public class ItemController implements ItemControllerDocs {
     @GetMapping("/{clubId}/items")
     public ListWrapperResponse<ItemResponse> getItems(@PathVariable Long clubId,
                                                       @RequestParam(required = false) String keyword,
-                                                      @RequestParam(required = false) String category) {
-        return ListWrapperResponse.of(itemService.getItemsByFilters(clubId, keyword, category));
+                                                      @RequestParam(required = false) String category,
+                                                      @RequestParam(required = false) Boolean using,
+                                                      @RequestParam(required = false) Boolean available) {
+        return ListWrapperResponse.of(itemService.getItemsByFilters(clubId, keyword, category, using, available));
     }
 
     @GetMapping("/{clubId}/items/{itemId}")

--- a/src/main/java/woohakdong/server/api/controller/item/ItemControllerDocs.java
+++ b/src/main/java/woohakdong/server/api/controller/item/ItemControllerDocs.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -29,7 +28,7 @@ public interface ItemControllerDocs {
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "물품 상세정보 반환", description = "물품 상세정보 반환")
     @ApiResponse(responseCode = "200", description = "물품 상세정보 반환 성공", useReturnTypeSchema = true)
-    public ItemResponse getItemInfo(@PathVariable Long clubId, @PathVariable Long itemId);
+    public ItemInfoResponse getItemInfo(@PathVariable Long clubId, @PathVariable Long itemId);
 
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "물품 대여", description = "물품이 사용중이 아니라면 대여할 수 있다.")

--- a/src/main/java/woohakdong/server/api/controller/item/ItemControllerDocs.java
+++ b/src/main/java/woohakdong/server/api/controller/item/ItemControllerDocs.java
@@ -23,7 +23,9 @@ public interface ItemControllerDocs {
     @ApiResponse(responseCode = "200", description = "물품 리스트 반환 성공", useReturnTypeSchema = true)
     public ListWrapperResponse<ItemResponse> getItems(@PathVariable Long clubId,
                                                       @RequestParam(required = false) String keyword,
-                                                      @RequestParam(required = false) String category);
+                                                      @RequestParam(required = false) String category,
+                                                      @RequestParam(required = false) Boolean using,
+                                                      @RequestParam(required = false) Boolean available);
 
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "물품 상세정보 반환", description = "물품 상세정보 반환")

--- a/src/main/java/woohakdong/server/api/controller/item/dto/ItemHistoryResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/item/dto/ItemHistoryResponse.java
@@ -2,6 +2,7 @@ package woohakdong.server.api.controller.item.dto;
 
 import lombok.Builder;
 import woohakdong.server.domain.ItemHistory.ItemHistory;
+import woohakdong.server.domain.item.Item;
 import woohakdong.server.domain.member.Member;
 
 import java.time.LocalDateTime;
@@ -14,9 +15,11 @@ public record ItemHistoryResponse(
         LocalDateTime itemRentalDate,
         LocalDateTime itemDueDate,
         LocalDateTime itemReturnDate,
-        String itemReturnImage
+        String itemReturnImage,
+        String itemName,
+        Boolean itemOverdue
 ) {
-    public static ItemHistoryResponse from(ItemHistory itemHistory, Long clubMemberId) {
+    public static ItemHistoryResponse from(ItemHistory itemHistory, Long clubMemberId, String itemName, Boolean itemOverdue) {
         return ItemHistoryResponse.builder()
                 .itemHistoryId(itemHistory.getItemHistoryId())
                 .clubMemberId(clubMemberId)
@@ -25,6 +28,8 @@ public record ItemHistoryResponse(
                 .itemDueDate(itemHistory.getItemDueDate())
                 .itemReturnDate(itemHistory.getItemReturnDate())
                 .itemReturnImage(itemHistory.getItemReturnImage())
+                .itemName(itemName)
+                .itemOverdue(itemOverdue)
                 .build();
     }
 }

--- a/src/main/java/woohakdong/server/api/controller/item/dto/ItemHistoryResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/item/dto/ItemHistoryResponse.java
@@ -17,9 +17,10 @@ public record ItemHistoryResponse(
         LocalDateTime itemReturnDate,
         String itemReturnImage,
         String itemName,
-        Boolean itemOverdue
+        Boolean itemOverdue,
+        Long itemId
 ) {
-    public static ItemHistoryResponse from(ItemHistory itemHistory, Long clubMemberId, String itemName, Boolean itemOverdue) {
+    public static ItemHistoryResponse from(ItemHistory itemHistory, Long clubMemberId, Item item, Boolean itemOverdue) {
         return ItemHistoryResponse.builder()
                 .itemHistoryId(itemHistory.getItemHistoryId())
                 .clubMemberId(clubMemberId)
@@ -28,8 +29,9 @@ public record ItemHistoryResponse(
                 .itemDueDate(itemHistory.getItemDueDate())
                 .itemReturnDate(itemHistory.getItemReturnDate())
                 .itemReturnImage(itemHistory.getItemReturnImage())
-                .itemName(itemName)
+                .itemName(item.getItemName())
                 .itemOverdue(itemOverdue)
+                .itemId(item.getItemId())
                 .build();
     }
 }

--- a/src/main/java/woohakdong/server/api/controller/item/dto/ItemHistoryResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/item/dto/ItemHistoryResponse.java
@@ -9,18 +9,18 @@ import java.time.LocalDateTime;
 @Builder
 public record ItemHistoryResponse(
         Long itemHistoryId,
-        Long memberId,
+        Long clubMemberId,
         String memberName,
         LocalDateTime itemRentalDate,
         LocalDateTime itemDueDate,
         LocalDateTime itemReturnDate,
         String itemReturnImage
 ) {
-    public static ItemHistoryResponse from(ItemHistory itemHistory, Member member) {
+    public static ItemHistoryResponse from(ItemHistory itemHistory, Long clubMemberId) {
         return ItemHistoryResponse.builder()
                 .itemHistoryId(itemHistory.getItemHistoryId())
-                .memberId(member.getMemberId())
-                .memberName(member.getMemberName())
+                .clubMemberId(clubMemberId)
+                .memberName(itemHistory.getMemberName())
                 .itemRentalDate(itemHistory.getItemRentalDate())
                 .itemDueDate(itemHistory.getItemDueDate())
                 .itemReturnDate(itemHistory.getItemReturnDate())

--- a/src/main/java/woohakdong/server/api/controller/item/dto/ItemInfoResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/item/dto/ItemInfoResponse.java
@@ -7,7 +7,7 @@ import woohakdong.server.domain.item.ItemCategory;
 import java.time.LocalDateTime;
 
 @Builder
-public record ItemResponse(
+public record ItemInfoResponse(
         Long itemId,
         String itemName,
         String itemPhoto,
@@ -18,12 +18,10 @@ public record ItemResponse(
         Boolean itemAvailable,
         Boolean itemUsing,
         LocalDateTime itemRentalDate,
-        Integer itemRentalTime,
-        String memberName,
-        Boolean itemOverdue
+        Integer itemRentalTime
 ) {
-    public static ItemResponse of(Item item, String memberName, Boolean itemOverdue) {
-        return ItemResponse.builder()
+    public static ItemInfoResponse of(Item item) {
+        return ItemInfoResponse.builder()
                 .itemId(item.getItemId())
                 .itemName(item.getItemName())
                 .itemPhoto(item.getItemPhoto())
@@ -35,8 +33,6 @@ public record ItemResponse(
                 .itemUsing(item.getItemUsing())
                 .itemRentalDate(item.getItemRentalDate())
                 .itemRentalTime(item.getItemRentalTime())
-                .memberName(memberName)
-                .itemOverdue(itemOverdue)
                 .build();
     }
 }

--- a/src/main/java/woohakdong/server/api/service/dues/DuesService.java
+++ b/src/main/java/woohakdong/server/api/service/dues/DuesService.java
@@ -60,7 +60,7 @@ public class DuesService {
             histories = clubAccountHistoryRepository.findMonthlyTransactions(clubAccount, year, month);
         } else {
             // 전체 거래 내역 조회
-            histories = clubAccountHistoryRepository.findAllByClubAccountClubClubId(clubId);
+            histories = clubAccountHistoryRepository.findAllByClubAccountClub(club);
         }
 
         // ClubAccountHistoryListResponse로 변환

--- a/src/main/java/woohakdong/server/api/service/item/ItemService.java
+++ b/src/main/java/woohakdong/server/api/service/item/ItemService.java
@@ -184,7 +184,7 @@ public class ItemService {
                     return ItemHistoryResponse.from(
                             history,
                             history.getClubMember().getClubMemberId(),
-                            item.getItemName(),
+                            item,
                             isOverdue
                     );
                 })
@@ -261,7 +261,7 @@ public class ItemService {
                     return ItemHistoryResponse.from(
                             history,
                             history.getClubMember().getClubMemberId(),
-                            history.getItem().getItemName(),
+                            history.getItem(),
                             isOverdue
                     );
                 })
@@ -286,7 +286,7 @@ public class ItemService {
                     return ItemHistoryResponse.from(
                             history,
                             history.getClubMember().getClubMemberId(),
-                            history.getItem().getItemName(),
+                            history.getItem(),
                             isOverdue
                     );
                 })

--- a/src/main/java/woohakdong/server/api/service/item/ItemService.java
+++ b/src/main/java/woohakdong/server/api/service/item/ItemService.java
@@ -175,7 +175,19 @@ public class ItemService {
         Item item = itemRepository.getById(itemId);
 
         List<ItemHistoryResponse> historyResponses = itemHistoryRepository.getAllByItem(item).stream()
-                .map(history -> ItemHistoryResponse.from(history, history.getClubMember().getClubMemberId()))
+                .map(history -> {
+                    Boolean isOverdue = history.getItemDueDate() != null && (
+                            (history.getItemReturnDate() == null && history.getItemDueDate().isBefore(LocalDateTime.now())) || // 반납되지 않았고 연체
+                                    (history.getItemReturnDate() != null && history.getItemReturnDate().isAfter(history.getItemDueDate())) // 반납이 연체된 날짜에 이루어짐
+                    );
+
+                    return ItemHistoryResponse.from(
+                            history,
+                            history.getClubMember().getClubMemberId(),
+                            item.getItemName(),
+                            isOverdue
+                    );
+                })
                 .collect(Collectors.toList());
 
         return historyResponses;
@@ -240,7 +252,19 @@ public class ItemService {
 
         List<ItemHistory> histories = itemHistoryRepository.getAllByMember(clubMember);
         List<ItemHistoryResponse> itemHistoryResponses = histories.stream()
-                .map(history -> ItemHistoryResponse.from(history, history.getClubMember().getClubMemberId()))
+                .map(history -> {
+                    Boolean isOverdue = history.getItemDueDate() != null && (
+                            (history.getItemReturnDate() == null && history.getItemDueDate().isBefore(LocalDateTime.now())) || // 반납되지 않았고 연체
+                                    (history.getItemReturnDate() != null && history.getItemReturnDate().isAfter(history.getItemDueDate())) // 반납이 연체된 날짜에 이루어짐
+                    );
+
+                    return ItemHistoryResponse.from(
+                            history,
+                            history.getClubMember().getClubMemberId(),
+                            history.getItem().getItemName(),
+                            isOverdue
+                    );
+                })
                 .collect(Collectors.toList());
 
         return itemHistoryResponses;
@@ -253,7 +277,19 @@ public class ItemService {
         List<ItemHistory> histories = itemHistoryRepository.getAllByClubAndMember(club, clubMember);
 
         List<ItemHistoryResponse> itemHistoryResponses = histories.stream()
-                .map(history -> ItemHistoryResponse.from(history, history.getClubMember().getClubMemberId()))
+                .map(history -> {
+                    Boolean isOverdue = history.getItemDueDate() != null && (
+                            (history.getItemReturnDate() == null && history.getItemDueDate().isBefore(LocalDateTime.now())) || // 반납되지 않았고 연체
+                                    (history.getItemReturnDate() != null && history.getItemReturnDate().isAfter(history.getItemDueDate())) // 반납이 연체된 날짜에 이루어짐
+                    );
+
+                    return ItemHistoryResponse.from(
+                            history,
+                            history.getClubMember().getClubMemberId(),
+                            history.getItem().getItemName(),
+                            isOverdue
+                    );
+                })
                 .collect(Collectors.toList());
 
         return itemHistoryResponses;

--- a/src/main/java/woohakdong/server/api/service/item/ItemService.java
+++ b/src/main/java/woohakdong/server/api/service/item/ItemService.java
@@ -62,23 +62,6 @@ public class ItemService {
 
         List<Item> items;
 
-        // 조건에 따른 분기 처리
-//        if ((keyword == null || keyword.isEmpty()) && (category == null || category.isEmpty())) {
-//            // 카테고리와 검색어 모두 없을 경우, 모든 물품 반환
-//            items = itemRepository.getAllByClub(club);
-//        } else if (keyword == null || keyword.isEmpty()) {
-//            // 카테고리는 있고 검색어는 없을 경우, 카테고리로만 필터링
-//            ItemCategory itemCategory = ItemCategory.valueOf(category.toUpperCase());
-//            items = itemRepository.getAllByClubAndItemCategory(club, itemCategory);
-//        } else if (category == null || category.isEmpty()) {
-//            // 검색어는 있고 카테고리는 없을 경우, 검색어로만 필터링
-//            items = itemRepository.getAllByClubAndNameContaining(club, keyword);
-//        } else {
-//            // 카테고리와 검색어 둘 다 있을 경우, 둘 다 필터링
-//            ItemCategory itemCategory = ItemCategory.valueOf(category.toUpperCase());
-//            items = itemRepository.getAllByClubAndItemNameAndItemCategoryContaining(club, itemCategory, keyword);
-//        }
-
         if (keyword == null && category == null && using == null && available == null) {
             items = itemRepository.getAllByClub(club);
         } else {

--- a/src/main/java/woohakdong/server/api/service/item/ItemService.java
+++ b/src/main/java/woohakdong/server/api/service/item/ItemService.java
@@ -57,26 +57,37 @@ public class ItemService {
     }
 
     @Transactional(readOnly = true)
-    public List<ItemResponse> getItemsByFilters(Long clubId, String keyword, String category) {
+    public List<ItemResponse> getItemsByFilters(Long clubId, String keyword, String category, Boolean using, Boolean available) {
         Club club = clubRepository.getById(clubId);
 
         List<Item> items;
 
         // 조건에 따른 분기 처리
-        if ((keyword == null || keyword.isEmpty()) && (category == null || category.isEmpty())) {
-            // 카테고리와 검색어 모두 없을 경우, 모든 물품 반환
+//        if ((keyword == null || keyword.isEmpty()) && (category == null || category.isEmpty())) {
+//            // 카테고리와 검색어 모두 없을 경우, 모든 물품 반환
+//            items = itemRepository.getAllByClub(club);
+//        } else if (keyword == null || keyword.isEmpty()) {
+//            // 카테고리는 있고 검색어는 없을 경우, 카테고리로만 필터링
+//            ItemCategory itemCategory = ItemCategory.valueOf(category.toUpperCase());
+//            items = itemRepository.getAllByClubAndItemCategory(club, itemCategory);
+//        } else if (category == null || category.isEmpty()) {
+//            // 검색어는 있고 카테고리는 없을 경우, 검색어로만 필터링
+//            items = itemRepository.getAllByClubAndNameContaining(club, keyword);
+//        } else {
+//            // 카테고리와 검색어 둘 다 있을 경우, 둘 다 필터링
+//            ItemCategory itemCategory = ItemCategory.valueOf(category.toUpperCase());
+//            items = itemRepository.getAllByClubAndItemNameAndItemCategoryContaining(club, itemCategory, keyword);
+//        }
+
+        if (keyword == null && category == null && using == null && available == null) {
             items = itemRepository.getAllByClub(club);
-        } else if (keyword == null || keyword.isEmpty()) {
-            // 카테고리는 있고 검색어는 없을 경우, 카테고리로만 필터링
-            ItemCategory itemCategory = ItemCategory.valueOf(category.toUpperCase());
-            items = itemRepository.getAllByClubAndItemCategory(club, itemCategory);
-        } else if (category == null || category.isEmpty()) {
-            // 검색어는 있고 카테고리는 없을 경우, 검색어로만 필터링
-            items = itemRepository.getAllByClubAndNameContaining(club, keyword);
         } else {
-            // 카테고리와 검색어 둘 다 있을 경우, 둘 다 필터링
-            ItemCategory itemCategory = ItemCategory.valueOf(category.toUpperCase());
-            items = itemRepository.getAllByClubAndItemNameAndItemCategoryContaining(club, itemCategory, keyword);
+            if (category == null || category.isEmpty()) {
+                items = itemRepository.getItemsByFilters(club, keyword, null, using, available);
+            } else {
+                ItemCategory itemCategory = ItemCategory.valueOf(category.toUpperCase());
+                items = itemRepository.getItemsByFilters(club, keyword, itemCategory, using, available);
+            }
         }
 
         List<ItemResponse> responses = new ArrayList<>();

--- a/src/main/java/woohakdong/server/api/service/item/ItemService.java
+++ b/src/main/java/woohakdong/server/api/service/item/ItemService.java
@@ -244,7 +244,7 @@ public class ItemService {
         Club club = clubRepository.getById(clubId);
         ClubMember clubMember = clubMemberRepository.getById(clubMemberId);
 
-        List<ItemHistory> histories = itemHistoryRepository.getAllByMember(clubMember.getMember());
+        List<ItemHistory> histories = itemHistoryRepository.getAllByClubAndMember(club, clubMember.getMember());
 
         List<ItemHistoryResponse> itemHistoryResponses = histories.stream()
                 .map(history -> ItemHistoryResponse.from(history, clubMember.getMember()))

--- a/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistory.java
+++ b/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistory.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import woohakdong.server.domain.BaseEntity;
+import woohakdong.server.domain.clubmember.ClubMember;
 import woohakdong.server.domain.item.Item;
 import woohakdong.server.domain.member.Member;
 
@@ -35,8 +36,10 @@ public class ItemHistory extends BaseEntity {
     private LocalDateTime itemDueDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @JoinColumn(name = "club_member_id")
+    private ClubMember clubMember;
+
+    private String memberName;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_id")
@@ -44,24 +47,26 @@ public class ItemHistory extends BaseEntity {
 
     @Builder
     private ItemHistory(String itemReturnImage, LocalDateTime itemRentalDate, LocalDateTime itemReturnDate,
-                        LocalDateTime itemDueDate, Member member, Item item) {
+                        LocalDateTime itemDueDate, ClubMember clubMember, Item item, String memberName) {
         this.itemReturnImage = itemReturnImage;
         this.itemRentalDate = itemRentalDate;
         this.itemReturnDate = itemReturnDate;
         this.itemDueDate = itemDueDate;
-        this.member = member;
+        this.clubMember = clubMember;
         this.item = item;
+        this.memberName = memberName;
     }
 
-    public static ItemHistory create(Member member, Item item, LocalDateTime itemRentalDate,
+    public static ItemHistory create(ClubMember clubMember, String memberName, Item item, LocalDateTime itemRentalDate,
                                      LocalDateTime itemDueDate) {
         return ItemHistory.builder()
                 .itemReturnImage(null)
                 .itemRentalDate(itemRentalDate)
                 .itemReturnDate(null)
                 .itemDueDate(itemDueDate)
-                .member(member)
+                .clubMember(clubMember)
                 .item(item)
+                .memberName(memberName)
                 .build();
 
     }

--- a/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistoryJpaRepository.java
+++ b/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistoryJpaRepository.java
@@ -6,15 +6,18 @@ import java.util.List;
 import java.util.Optional;
 
 import woohakdong.server.domain.club.Club;
+import woohakdong.server.domain.clubmember.ClubMember;
 import woohakdong.server.domain.item.Item;
 import woohakdong.server.domain.member.Member;
 
 public interface ItemHistoryJpaRepository extends JpaRepository<ItemHistory, Long> {
-    Optional<ItemHistory> findByItemAndMemberAndItemReturnDateIsNull(Item item, Member member);
+    Optional<ItemHistory> findByItemAndClubMemberAndItemReturnDateIsNull(Item item, ClubMember clubMember);
 
     List<ItemHistory> findByItemOrderByItemRentalDateDesc(Item item);
 
-    List<ItemHistory> findByMemberOrderByItemRentalDateDesc(Member member);
+    List<ItemHistory> findByClubMemberOrderByItemRentalDateDesc(ClubMember clubMember);
 
-    List<ItemHistory> findByItemClubAndMemberOrderByItemRentalDateDesc(Club club, Member member);
+    List<ItemHistory> findByItemClubAndClubMemberOrderByItemRentalDateDesc(Club club, ClubMember clubMember);
+
+    Optional<ItemHistory> findByItemAndItemReturnDateIsNull(Item item);
 }

--- a/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistoryJpaRepository.java
+++ b/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistoryJpaRepository.java
@@ -5,13 +5,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
+import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.item.Item;
 import woohakdong.server.domain.member.Member;
 
 public interface ItemHistoryJpaRepository extends JpaRepository<ItemHistory, Long> {
     Optional<ItemHistory> findByItemAndMemberAndItemReturnDateIsNull(Item item, Member member);
 
-    List<ItemHistory> findByItem(Item item);
+    List<ItemHistory> findByItemOrderByItemRentalDateDesc(Item item);
 
-    List<ItemHistory> findByMember(Member member);
+    List<ItemHistory> findByMemberOrderByItemRentalDateDesc(Member member);
+
+    List<ItemHistory> findByItemClubAndMemberOrderByItemRentalDateDesc(Club club, Member member);
 }

--- a/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistoryRepository.java
+++ b/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistoryRepository.java
@@ -3,6 +3,7 @@ package woohakdong.server.domain.ItemHistory;
 import java.util.List;
 
 import woohakdong.server.domain.club.Club;
+import woohakdong.server.domain.clubmember.ClubMember;
 import woohakdong.server.domain.item.Item;
 import woohakdong.server.domain.member.Member;
 
@@ -11,11 +12,13 @@ public interface ItemHistoryRepository {
 
     ItemHistory getById(Long itemHistoryId);
 
-    ItemHistory getActiveBorrowingRecord(Item item, Member member);
+    ItemHistory getActiveBorrowingRecord(Item item, ClubMember clubMember);
 
     List<ItemHistory> getAllByItem(Item item);
 
-    List<ItemHistory> getAllByMember(Member member);
+    List<ItemHistory> getAllByMember(ClubMember clubMember);
 
-    List<ItemHistory> getAllByClubAndMember(Club club, Member member);
+    List<ItemHistory> getAllByClubAndMember(Club club, ClubMember clubMember);
+
+    ItemHistory getByItemAndItemReturnDateIsNull(Item item);
 }

--- a/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistoryRepository.java
+++ b/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistoryRepository.java
@@ -1,6 +1,8 @@
 package woohakdong.server.domain.ItemHistory;
 
 import java.util.List;
+
+import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.item.Item;
 import woohakdong.server.domain.member.Member;
 
@@ -14,4 +16,6 @@ public interface ItemHistoryRepository {
     List<ItemHistory> getAllByItem(Item item);
 
     List<ItemHistory> getAllByMember(Member member);
+
+    List<ItemHistory> getAllByClubAndMember(Club club, Member member);
 }

--- a/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistoryRepositoryImpl.java
+++ b/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistoryRepositoryImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import woohakdong.server.common.exception.CustomErrorInfo;
 import woohakdong.server.common.exception.CustomException;
+import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.item.Item;
 import woohakdong.server.domain.member.Member;
 
@@ -33,10 +34,16 @@ public class ItemHistoryRepositoryImpl implements ItemHistoryRepository{
 
     @Override
     public List<ItemHistory> getAllByItem(Item item) {
-        return itemHistoryJpaRepository.findByItem(item);
+        return itemHistoryJpaRepository.findByItemOrderByItemRentalDateDesc(item);
     }
 
+    @Override
     public List<ItemHistory> getAllByMember(Member member) {
-        return itemHistoryJpaRepository.findByMember(member);
+        return itemHistoryJpaRepository.findByMemberOrderByItemRentalDateDesc(member);
+    }
+
+    @Override
+    public List<ItemHistory> getAllByClubAndMember(Club club, Member member) {
+        return itemHistoryJpaRepository.findByItemClubAndMemberOrderByItemRentalDateDesc(club, member);
     }
 }

--- a/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistoryRepositoryImpl.java
+++ b/src/main/java/woohakdong/server/domain/ItemHistory/ItemHistoryRepositoryImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 import woohakdong.server.common.exception.CustomErrorInfo;
 import woohakdong.server.common.exception.CustomException;
 import woohakdong.server.domain.club.Club;
+import woohakdong.server.domain.clubmember.ClubMember;
 import woohakdong.server.domain.item.Item;
 import woohakdong.server.domain.member.Member;
 
@@ -27,8 +28,8 @@ public class ItemHistoryRepositoryImpl implements ItemHistoryRepository{
     }
 
     @Override
-    public ItemHistory getActiveBorrowingRecord(Item item, Member member) {
-        return itemHistoryJpaRepository.findByItemAndMemberAndItemReturnDateIsNull(item, member)
+    public ItemHistory getActiveBorrowingRecord(Item item, ClubMember clubMember) {
+        return itemHistoryJpaRepository.findByItemAndClubMemberAndItemReturnDateIsNull(item, clubMember)
                 .orElseThrow(() -> new CustomException(CustomErrorInfo.ITEM_HISTORY_NOT_FOUND));
     }
 
@@ -38,12 +39,18 @@ public class ItemHistoryRepositoryImpl implements ItemHistoryRepository{
     }
 
     @Override
-    public List<ItemHistory> getAllByMember(Member member) {
-        return itemHistoryJpaRepository.findByMemberOrderByItemRentalDateDesc(member);
+    public List<ItemHistory> getAllByMember(ClubMember clubMember) {
+        return itemHistoryJpaRepository.findByClubMemberOrderByItemRentalDateDesc(clubMember);
     }
 
     @Override
-    public List<ItemHistory> getAllByClubAndMember(Club club, Member member) {
-        return itemHistoryJpaRepository.findByItemClubAndMemberOrderByItemRentalDateDesc(club, member);
+    public List<ItemHistory> getAllByClubAndMember(Club club, ClubMember clubMember) {
+        return itemHistoryJpaRepository.findByItemClubAndClubMemberOrderByItemRentalDateDesc(club, clubMember);
+    }
+
+    @Override
+    public ItemHistory getByItemAndItemReturnDateIsNull(Item item) {
+        return itemHistoryJpaRepository.findByItemAndItemReturnDateIsNull(item)
+                .orElseThrow(() -> new CustomException(CustomErrorInfo.ITEM_HISTORY_NOT_FOUND));
     }
 }

--- a/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryJpaRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryJpaRepository.java
@@ -3,6 +3,7 @@ package woohakdong.server.domain.clubAccountHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.clubAccount.ClubAccount;
 
 import java.util.List;
@@ -18,5 +19,5 @@ public interface ClubAccountHistoryJpaRepository extends JpaRepository<ClubAccou
                                                      @Param("year") int year,
                                                      @Param("month") int month);
 
-    List<ClubAccountHistory> findAllByClubAccountClubClubId(Long clubId);
+    List<ClubAccountHistory> findAllByClubAccountClubOrderByClubAccountHistoryTranDateDesc(Club club);
 }

--- a/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryRepository.java
@@ -1,6 +1,8 @@
 package woohakdong.server.domain.clubAccountHistory;
 
 import java.util.List;
+
+import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.clubAccount.ClubAccount;
 
 public interface ClubAccountHistoryRepository {
@@ -10,5 +12,5 @@ public interface ClubAccountHistoryRepository {
 
     List<ClubAccountHistory> findMonthlyTransactions(ClubAccount clubAccount, int year, int month);
 
-    List<ClubAccountHistory> findAllByClubAccountClubClubId(Long clubId);
+    List<ClubAccountHistory> findAllByClubAccountClub(Club club);
 }

--- a/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryRepositoryImpl.java
+++ b/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryRepositoryImpl.java
@@ -3,6 +3,7 @@ package woohakdong.server.domain.clubAccountHistory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.clubAccount.ClubAccount;
 
 @RequiredArgsConstructor
@@ -28,7 +29,7 @@ public class ClubAccountHistoryRepositoryImpl implements ClubAccountHistoryRepos
     }
 
     @Override
-    public List<ClubAccountHistory> findAllByClubAccountClubClubId(Long clubId) {
-        return clubAccountHistoryJpaRepository.findAllByClubAccountClubClubId(clubId);
+    public List<ClubAccountHistory> findAllByClubAccountClub(Club club) {
+        return clubAccountHistoryJpaRepository.findAllByClubAccountClubOrderByClubAccountHistoryTranDateDesc(club);
     }
 }

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
@@ -48,7 +48,7 @@ public class ClubMember extends BaseEntity {
     private Club club;
 
     @Builder
-    private ClubMember(Club club, LocalDate clubJoinedDate, LocalDate clubMemberAssignedTerm,
+    public ClubMember(Club club, LocalDate clubJoinedDate, LocalDate clubMemberAssignedTerm,
                        ClubMemberRole clubMemberRole, Member member) {
         this.club = club;
         this.clubJoinedDate = clubJoinedDate;

--- a/src/main/java/woohakdong/server/domain/item/ItemJpaRepository.java
+++ b/src/main/java/woohakdong/server/domain/item/ItemJpaRepository.java
@@ -25,4 +25,16 @@ public interface ItemJpaRepository extends JpaRepository<Item, Long> {
     List<Item> findAllByClubAndItemNameAndItemCategoryContaining(Club club, String keyword, ItemCategory category);
 
     Long countByClubSchool(School school);
+
+    @Query("SELECT i FROM Item i " +
+            "WHERE i.club = :club " +
+            "AND (:keyword IS NULL OR i.itemName LIKE %:keyword%) " +
+            "AND (:category IS NULL OR i.itemCategory = :category) " +
+            "AND (:using IS NULL OR i.itemUsing = :using) " +
+            "AND (:available IS NULL OR i.itemAvailable = :available)")
+    List<Item> findItemsByFilters(@Param("club") Club club,
+                                  @Param("keyword") String keyword,
+                                  @Param("category") ItemCategory category,
+                                  @Param("using") Boolean using,
+                                  @Param("available") Boolean available);
 }

--- a/src/main/java/woohakdong/server/domain/item/ItemRepository.java
+++ b/src/main/java/woohakdong/server/domain/item/ItemRepository.java
@@ -1,6 +1,8 @@
 package woohakdong.server.domain.item;
 
 import java.util.List;
+
+import org.springframework.data.repository.query.Param;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.school.School;
 
@@ -22,4 +24,6 @@ public interface ItemRepository {
     List<Item> getAllByClubAndItemNameAndItemCategoryContaining(Club club, ItemCategory category, String keyword);
 
     Long countByClubSchool(School school);
+
+    List<Item> getItemsByFilters(Club club, String keyword, ItemCategory category, Boolean using, Boolean available);
 }

--- a/src/main/java/woohakdong/server/domain/item/ItemRepositoryImpl.java
+++ b/src/main/java/woohakdong/server/domain/item/ItemRepositoryImpl.java
@@ -64,4 +64,9 @@ public class ItemRepositoryImpl implements ItemRepository {
         return itemJpaRepository.countByClubSchool(school);
     }
 
+    @Override
+    public List<Item> getItemsByFilters(Club club, String keyword, ItemCategory category, Boolean using, Boolean available){
+        return itemJpaRepository.findItemsByFilters(club, keyword, category, using, available);
+    }
+
 }

--- a/src/test/java/woohakdong/server/api/service/item/ItemServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/item/ItemServiceTest.java
@@ -19,7 +19,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-import woohakdong.server.api.controller.ListWrapperResponse;
 import woohakdong.server.api.controller.item.dto.*;
 import woohakdong.server.common.exception.CustomException;
 import woohakdong.server.common.security.jwt.CustomUserDetails;
@@ -190,10 +189,11 @@ class ItemServiceTest {
         Member member = setUpMemberSession();
         Club club = createClub();
         Item item = createItem(club, "축구공", SPORT, 7, false);
+        ClubMember clubMember = createClubMember(club, member, MEMBER, getAssignedTerm(LocalDate.now()));
 
         LocalDateTime now = LocalDateTime.now();
-        createItemHistory(item, member, now.minusDays(10), now.minusDays(3), now.minusDays(2));
-        createItemHistory(item, member, now, now.plusDays(7), null);
+        createItemHistory(item, clubMember, now.minusDays(10), now.minusDays(3), now.minusDays(2));
+        createItemHistory(item, clubMember, now, now.plusDays(7), null);
 
         // when
         List<ItemHistoryResponse> itemHistoryResponses = itemService.getItemHistory(club.getClubId(), item.getItemId());
@@ -295,7 +295,7 @@ class ItemServiceTest {
         Item item = createItem(club, "축구공", SPORT, 7, false);
 
         // when
-        ItemResponse response = itemService.getItemInfo(club.getClubId(), item.getItemId());
+        ItemInfoResponse response = itemService.getItemInfo(club.getClubId(), item.getItemId());
 
         // then
         assertThat(response)
@@ -313,7 +313,7 @@ class ItemServiceTest {
         ClubMember clubMember = createClubMember(club, member, MEMBER, getAssignedTerm(LocalDate.now()));
 
         LocalDateTime now = LocalDateTime.of(2024, 11, 8, 2, 17, 4, 844856);
-        ItemHistory itemHistory = createItemHistory(item, member, now.minusDays(10), now.minusDays(3), now.minusDays(2));
+        ItemHistory itemHistory = createItemHistory(item, clubMember, now.minusDays(10), now.minusDays(3), now.minusDays(2));
 
         // when
         List<ItemHistoryResponse> response = itemService.getMyHistoryItems(club.getClubId());
@@ -335,7 +335,7 @@ class ItemServiceTest {
         ClubMember clubMember = createClubMember(club, member, MEMBER, getAssignedTerm(LocalDate.now()));
 
         LocalDateTime now = LocalDateTime.of(2024, 11, 8, 2, 17, 4, 844856);
-        ItemHistory itemHistory = createItemHistory(item, member, now.minusDays(10), now.minusDays(3), now.minusDays(2));
+        ItemHistory itemHistory = createItemHistory(item, clubMember, now.minusDays(10), now.minusDays(3), now.minusDays(2));
 
         // when
         List<ItemHistoryResponse> response = itemService.getClubMemberHistoryItems(club.getClubId(), clubMember.getClubMemberId());
@@ -428,11 +428,11 @@ class ItemServiceTest {
                 .build();
     }
 
-    private ItemHistory createItemHistory(Item item, Member member, LocalDateTime rentalDate, LocalDateTime dueDate,
+    private ItemHistory createItemHistory(Item item, ClubMember clubMember, LocalDateTime rentalDate, LocalDateTime dueDate,
                                    LocalDateTime returnDate) {
         ItemHistory itemHistory = ItemHistory.builder()
                 .item(item)
-                .member(member)
+                .clubMember(clubMember)
                 .itemRentalDate(rentalDate) // 10일 전 대여
                 .itemDueDate(dueDate)     // 3일 전에 반납 예정
                 .itemReturnDate(returnDate)  // 2일 전에 반납됨

--- a/src/test/java/woohakdong/server/api/service/item/ItemServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/item/ItemServiceTest.java
@@ -358,7 +358,29 @@ class ItemServiceTest {
         Item item = createItem(club, "축구공", SPORT, 7, false);
         ClubMember clubMember = createClubMember(club, member, MEMBER, getAssignedTerm(LocalDate.now()));
 
-        LocalDateTime now = LocalDateTime.of(2024, 11, 8, 2, 17, 4, 844856);
+        LocalDateTime now = LocalDateTime.now();
+        ItemHistory itemHistory = createItemHistory(item, clubMember, now.minusDays(10), now.minusDays(3), null);
+
+        // when
+        List<ItemHistoryResponse> response = itemService.getClubMemberHistoryItems(club.getClubId(), clubMember.getClubMemberId());
+
+        // then
+        assertThat(response)
+                .isNotEmpty()
+                .extracting("itemRentalDate", "itemDueDate", "itemName", "itemOverdue")
+                .containsExactly(tuple(now.minusDays(10), now.minusDays(3), "축구공", true));
+    }
+
+    @DisplayName("동아리 회원의 물품 대여 기록 연체된 것을 확인할 수 있다.")
+    @Test
+    void getClubMemberHistoryItemsOverdue_success() {
+        // given
+        Member member = setUpMemberSession();
+        Club club = createClub();
+        Item item = createItem(club, "축구공", SPORT, 7, false);
+        ClubMember clubMember = createClubMember(club, member, MEMBER, getAssignedTerm(LocalDate.now()));
+
+        LocalDateTime now = LocalDateTime.now();
         ItemHistory itemHistory = createItemHistory(item, clubMember, now.minusDays(10), now.minusDays(3), now.minusDays(2));
 
         // when
@@ -367,8 +389,8 @@ class ItemServiceTest {
         // then
         assertThat(response)
                 .isNotEmpty()
-                .extracting("itemRentalDate", "itemDueDate")
-                .containsExactly(tuple(now.minusDays(10), now.minusDays(3)));
+                .extracting("itemRentalDate", "itemDueDate", "itemName", "itemOverdue")
+                .containsExactly(tuple(now.minusDays(10), now.minusDays(3), "축구공", true));
     }
 
     private ItemBorrowed createItemBorrowed(ClubMember clubMember, Item item) {

--- a/src/test/java/woohakdong/server/api/service/item/ItemServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/item/ItemServiceTest.java
@@ -93,7 +93,7 @@ class ItemServiceTest {
         createItem(club, "농구공", SPORT, 7, false);
 
         // When
-        List<ItemResponse> items = itemService.getItemsByFilters(club.getClubId(), null, null);
+        List<ItemResponse> items = itemService.getItemsByFilters(club.getClubId(), null, null, null, null);
 
         // Then
         assertThat(items).hasSize(2)
@@ -218,7 +218,7 @@ class ItemServiceTest {
         createItem(club, "농구공", SPORT, 5, false);
 
         // when
-        List<ItemResponse> items = itemService.getItemsByFilters(club.getClubId(), "공", "");
+        List<ItemResponse> items = itemService.getItemsByFilters(club.getClubId(), "공", "", false, true);
 
         // then
         assertThat(items).hasSize(2)
@@ -227,6 +227,30 @@ class ItemServiceTest {
                         tuple("축구공", SPORT, 7),
                         tuple("농구공", SPORT, 5)
                 );
+    }
+
+    @DisplayName("사용중인 물품을 검색할 수 있다.")
+    @Test
+    void searchItemsByUsing_success() {
+        // given
+        Member member = setUpMemberSession();
+
+        Club club = createClub();
+        createItem(club, "축구공", SPORT, 7, false);
+        Item item = createItem(club, "농구공", SPORT, 5, true);
+        ClubMember clubMember = createClubMember(club, member, MEMBER, getAssignedTerm(LocalDate.now()));
+        LocalDateTime now = LocalDateTime.now();
+        ItemHistory itemHistory = createItemHistory(item, clubMember, now.minusDays(10), now.minusDays(3), null);
+
+        // when
+        List<ItemResponse> items = itemService.getItemsByFilters(club.getClubId(), "공", "", true, true);
+
+        // then
+        assertThat(items)
+                .hasSize(1)
+                .extracting("itemName", "itemCategory", "itemRentalMaxDay", "itemUsing")
+                .containsExactly(tuple("농구공", ItemCategory.SPORT, 5, true));
+
     }
 
     @DisplayName("물품 이용 가능을 수정할 수 있다.")

--- a/src/test/java/woohakdong/server/api/service/item/ItemServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/item/ItemServiceTest.java
@@ -202,8 +202,8 @@ class ItemServiceTest {
         assertThat(itemHistoryResponses)
                 .extracting("itemRentalDate", "itemDueDate", "itemReturnDate")
                 .containsExactly(
-                        tuple(now.minusDays(10), now.minusDays(3), now.minusDays(2)),
-                        tuple(now, now.plusDays(7), null)
+                        tuple(now, now.plusDays(7), null),
+                        tuple(now.minusDays(10), now.minusDays(3), now.minusDays(2))
                 );
     }
 


### PR DESCRIPTION
### 기능 설명

- 회비 내역, 물품 대여 내력 날짜별 내림차순
- itemHistory 연관관계 clubMember로 변환
- 물품 리스트에 대여 시 대여자 추가
- 물품 리스트에 연체 시 연체 여부 추가
- 물품 사용여부, 가능 여부에 따른 물품 리스트 목록 반환 api 작성

### 작성 상세 내용

- 회비 내역, 물품 대여 내력 날짜별 내림차순
- itemHistory 연관관계 clubMember로 변환
-> 동아리 물품은 동아리 회원만이 빌릴 수 있음
- 물품 리스트에 대여 시 대여자 추가
- 물품 리스트에 연체 시 연체 여부 추가
- 물품 사용여부, 가능 여부에 따른 물품 리스트 목록 반환 api 작성

### 관련 지라 티켓 번호
[WHD-251](https://8901dev.atlassian.net/jira/software/projects/WHD/boards/1?selectedIssue=WHD-251)
### 참고 자료


[WHD-251]: https://8901dev.atlassian.net/browse/WHD-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ