### PR TITLE
[WHD-275] Feat: Add two days for monthly schedule

### DIFF
--- a/src/main/java/woohakdong/server/api/service/schedule/ScheduleService.java
+++ b/src/main/java/woohakdong/server/api/service/schedule/ScheduleService.java
@@ -65,8 +65,9 @@ public class ScheduleService {
     public List<ScheduleInfoResponse> getSchedules(Long clubId, LocalDate date) {
         Club club = clubRepository.getById(clubId);
 
-        LocalDateTime startDate = LocalDate.of(date.getYear(), date.getMonth(), 1).atStartOfDay();
-        LocalDateTime endDate = startDate.plusMonths(1).minusDays(1).withHour(23).withMinute(59).withSecond(59);
+        // 저번 달 마지막 날부터 다음 달 첫 날까지의 스케줄을 가져온다. ( 프론트 달력 이벤트 이슈로 인해 )
+        LocalDateTime startDate = LocalDate.of(date.getYear(), date.getMonth(), 1).atStartOfDay().minusDays(1);
+        LocalDateTime endDate = startDate.plusMonths(1).plusDays(1).withHour(23).withMinute(59).withSecond(59);
 
         return scheduleRepository.getSchedulesWithPeriod(club, startDate, endDate)
                 .stream()

--- a/src/test/java/woohakdong/server/api/service/schedule/ScheduleServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/schedule/ScheduleServiceTest.java
@@ -144,11 +144,11 @@ class ScheduleServiceTest {
     void getSchedules() {
         // Given
         Long clubId = club.getClubId();
-        createSchedule("스프링 스터디", "특강", of(2024, 10, 30, 20, 0));
+        createSchedule("스프링 스터디", "특강", of(2024, 10, 1, 20, 0));
         createSchedule("리액트 스터디", "1회차", of(2024, 11, 1, 20, 0));
         createSchedule("리액트 스터디", "2회차", of(2024, 11, 15, 20, 0));
         createSchedule("리액트 스터디", "3회차", of(2024, 11, 29, 20, 0));
-        createSchedule("플러터 스터디", "왕기초 특강", of(2024, 12, 1, 20, 0));
+        createSchedule("플러터 스터디", "왕기초 특강", of(2024, 12, 25, 20, 0));
 
         // When
         List<ScheduleInfoResponse> response = scheduleService.getSchedules(clubId, LocalDate.of(2024, 11, 1));
@@ -160,6 +160,34 @@ class ScheduleServiceTest {
                         tuple("리액트 스터디", "1회차", of(2024, 11, 1, 20, 0)),
                         tuple("리액트 스터디", "2회차", of(2024, 11, 15, 20, 0)),
                         tuple("리액트 스터디", "3회차", of(2024, 11, 29, 20, 0))
+                );
+    }
+
+    @DisplayName("특정 달의 동아리 일정을 불러올 때, 전 달의 마지막날과 다음 달의 첫날을 포함한다.")
+    @Test
+    void getSchedulesWithTwoDays() {
+        // Given
+        Long clubId = club.getClubId();
+        createSchedule("OBYB", "선후배와의 만남", of(2024, 10, 30, 23, 59));
+        createSchedule("스프링 스터디", "특강", of(2024, 10, 31, 0, 0));
+        createSchedule("리액트 스터디", "1회차", of(2024, 11, 1, 20, 0));
+        createSchedule("리액트 스터디", "2회차", of(2024, 11, 30, 20, 0));
+        createSchedule("플러터 스터디", "입문편", of(2024, 12, 1, 0, 0));
+        createSchedule("플러터 스터디", "기본편", of(2024, 12, 1, 23, 59));
+        createSchedule("플러터 스터디", "고급편", of(2024, 12, 2, 0, 0));
+
+        // When
+        List<ScheduleInfoResponse> response = scheduleService.getSchedules(clubId, LocalDate.of(2024, 11, 15));
+
+        // Then
+        assertThat(response).hasSize(5)
+                .extracting("scheduleTitle", "scheduleContent", "scheduleDateTime")
+                .containsExactlyInAnyOrder(
+                        tuple("스프링 스터디", "특강", of(2024, 10, 31, 0, 0)),
+                        tuple("리액트 스터디", "1회차", of(2024, 11, 1, 20, 0)),
+                        tuple("리액트 스터디", "2회차", of(2024, 11, 30, 20, 0)),
+                        tuple("플러터 스터디", "입문편", of(2024, 12, 1, 0, 0)),
+                        tuple("플러터 스터디", "기본편", of(2024, 12, 1, 23, 59))
                 );
     }
 


### PR DESCRIPTION
### 기능 설명
월간 일정 데이터 형식 관련 변경

### 작성 상세 내용
- 월 단위의 일정 조회 시에, 전 달의 마지막 날과 다음 달의 첫 날을 포함하여 제공한다.
- 프론트 단에서 달력 이동 시, 이벤트 처리를 위함이다.

### 관련 지라 티켓 번호
[WHD-275]

[WHD-275]: https://8901dev.atlassian.net/browse/WHD-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ