### PR TITLE
[WHD-210] Feat: Club service payment

### DIFF
--- a/src/main/java/woohakdong/server/api/controller/club/ClubController.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubController.java
@@ -19,10 +19,10 @@ import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
 import woohakdong.server.api.controller.club.dto.ClubHistoryTermResponse;
 import woohakdong.server.api.controller.club.dto.ClubIdResponse;
 import woohakdong.server.api.controller.club.dto.ClubInfoResponse;
-import woohakdong.server.api.controller.club.dto.ClubJoinGroupInfoResponse;
 import woohakdong.server.api.controller.club.dto.ClubNameValidateRequest;
 import woohakdong.server.api.controller.club.dto.ClubSummaryResponse;
 import woohakdong.server.api.controller.club.dto.ClubUpdateRequest;
+import woohakdong.server.api.controller.group.dto.GroupInfoResponse;
 import woohakdong.server.api.service.bank.BankService;
 import woohakdong.server.api.service.club.ClubService;
 
@@ -70,7 +70,7 @@ public class ClubController implements ClubControllerDocs {
     }
 
     @GetMapping("/{clubId}/join")
-    public ClubJoinGroupInfoResponse getClubJoinInfo(@PathVariable Long clubId) {
+    public GroupInfoResponse getClubJoinInfo(@PathVariable Long clubId) {
         return clubService.getClubJoinInfo(clubId);
     }
 
@@ -94,4 +94,8 @@ public class ClubController implements ClubControllerDocs {
         clubService.checkClubExpired(clubId, LocalDate.now());
     }
 
+    @GetMapping("/{clubId}/payment-group")
+    public GroupInfoResponse getClubPaymentGroupInfo(@PathVariable Long clubId) {
+        return clubService.getGroupPaymentInfo(clubId);
+    }
 }

--- a/src/main/java/woohakdong/server/api/controller/club/ClubController.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubController.java
@@ -61,7 +61,7 @@ public class ClubController implements ClubControllerDocs {
 
     @PostMapping("/{clubId}/accounts")
     public void registerClubAccount(@PathVariable Long clubId, @RequestBody ClubAccountRegisterRequest request) {
-        clubService.registerClubAccount(clubId, request);
+        clubService.registerClubAccount(clubId, request, LocalDate.now());
     }
 
     @PostMapping("/accounts/validate")

--- a/src/main/java/woohakdong/server/api/controller/club/ClubControllerDocs.java
+++ b/src/main/java/woohakdong/server/api/controller/club/ClubControllerDocs.java
@@ -14,10 +14,10 @@ import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
 import woohakdong.server.api.controller.club.dto.ClubHistoryTermResponse;
 import woohakdong.server.api.controller.club.dto.ClubIdResponse;
 import woohakdong.server.api.controller.club.dto.ClubInfoResponse;
-import woohakdong.server.api.controller.club.dto.ClubJoinGroupInfoResponse;
 import woohakdong.server.api.controller.club.dto.ClubNameValidateRequest;
 import woohakdong.server.api.controller.club.dto.ClubSummaryResponse;
 import woohakdong.server.api.controller.club.dto.ClubUpdateRequest;
+import woohakdong.server.api.controller.group.dto.GroupInfoResponse;
 
 @Tag(name = "Club", description = "동아리 관련 API")
 public interface ClubControllerDocs {
@@ -60,7 +60,7 @@ public interface ClubControllerDocs {
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "동아리 가입 요청을 위한 정보 불러오기", description = "동아리원들에게 제공할 링크 및 정보를 제공합니다.")
     @ApiResponse(responseCode = "200", description = "동아리 가입 요청을 위한 정보 불러오기 성공", useReturnTypeSchema = true)
-    public ClubJoinGroupInfoResponse getClubJoinInfo(Long clubId);
+    public GroupInfoResponse getClubJoinInfo(Long clubId);
 
     @SecurityRequirement(name = "accessToken")
     @Operation(summary = "가입한 동아리 목록 불러오기", description = "가입한 동아리 목록을 불러옵니다.")
@@ -79,4 +79,9 @@ public interface ClubControllerDocs {
     @Operation(summary = "동아리 사용 가능 여부 확인하기", description = "서비스 사용료 납부에 따른 동아리 사용 가능 여부를 확인합니다.")
     @ApiResponse(responseCode = "200", description = "동아리 사용 가능")
     public void checkClubExpired(Long clubId);
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "동아리 서비스 사용료 납부 정보 획득하기", description = "서비스 사용료 납부 정보를 획득합니다.")
+    @ApiResponse(responseCode = "200", description = "동아리 서비스 사용료 납부 정보 획득 성공", useReturnTypeSchema = true)
+    public GroupInfoResponse getClubPaymentGroupInfo(Long clubId);
 }

--- a/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberController.java
+++ b/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberController.java
@@ -44,6 +44,6 @@ public class ClubMemberController implements ClubMemberControllerDocs {
     public void changeRole(@PathVariable Long clubId,
                            @PathVariable Long clubMemberId,
                            @RequestParam ClubMemberRole clubMemberRole) {
-        clubMemberService.changeClubMemberRole(clubId, clubMemberId, clubMemberRole);
+        clubMemberService.changeClubMemberRole(clubId, clubMemberId, clubMemberRole, LocalDate.now());
     }
 }

--- a/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberController.java
+++ b/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberController.java
@@ -23,8 +23,11 @@ public class ClubMemberController implements ClubMemberControllerDocs {
     @GetMapping("/{clubId}/members")
     public ListWrapperResponse<ClubMemberInfoResponse> getFilteredMembers(@PathVariable Long clubId,
                                                                           @RequestParam(required = false) LocalDate clubMemberAssignedTerm,
-                                                                          @RequestParam(required = false) String name){
-            return ListWrapperResponse.of(clubMemberService.getFilteredMembers(clubId, name, clubMemberAssignedTerm));
+                                                                          @RequestParam(required = false) String name) {
+        if (clubMemberAssignedTerm == null) {
+            clubMemberAssignedTerm = LocalDate.now();
+        }
+        return ListWrapperResponse.of(clubMemberService.getFilteredMembers(clubId, name, clubMemberAssignedTerm));
     }
 
     @GetMapping("/{clubId}/members/{clubMemberId}")
@@ -34,7 +37,7 @@ public class ClubMemberController implements ClubMemberControllerDocs {
 
     @GetMapping("/{clubId}/members/me")
     public ClubMemberInfoResponse getMyInfo(@PathVariable Long clubId) {
-        return clubMemberService.getMyInfo(clubId);
+        return clubMemberService.getMyInfo(clubId, LocalDate.now());
     }
 
     @PutMapping("/{clubId}/members/{clubMemberId}/role")

--- a/src/main/java/woohakdong/server/api/controller/group/GroupController.java
+++ b/src/main/java/woohakdong/server/api/controller/group/GroupController.java
@@ -1,5 +1,6 @@
 package woohakdong.server.api.controller.group;
 
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,7 +34,7 @@ public class GroupController implements GroupControllerDocs {
     }
 
     @PostMapping("/payment/webhook")
-    public void portOnePaymentComplete(@RequestBody PortOneWebhookRequest request) {
+    public void portOnePaymentComplete(@Valid @RequestBody PortOneWebhookRequest request) {
         orderService.portOnePaymentComplete(request, LocalDate.now());
     }
 }

--- a/src/main/java/woohakdong/server/api/controller/group/GroupController.java
+++ b/src/main/java/woohakdong/server/api/controller/group/GroupController.java
@@ -31,7 +31,7 @@ public class GroupController implements GroupControllerDocs {
     public void completeClubJoinOrder(
             @PathVariable Long groupId,
             @RequestBody PaymentCompleteReqeust request) {
-        orderService.confirmJoinOrder(groupId, request, LocalDate.now());
+        orderService.confirmOrderPayment(groupId, request, LocalDate.now());
     }
 
     @PostMapping("/payment/webhook")

--- a/src/main/java/woohakdong/server/api/controller/group/GroupController.java
+++ b/src/main/java/woohakdong/server/api/controller/group/GroupController.java
@@ -20,17 +20,15 @@ public class GroupController implements GroupControllerDocs {
 
     private final OrderService orderService;
 
-    @PostMapping("/{groupId}/joins")
-    public OrderIdResponse createClubJoinOrder(
-            @PathVariable Long groupId,
-            @RequestBody CreateOrderRequest request) {
+    @PostMapping("/{groupId}/orders")
+    public OrderIdResponse createClubJoinOrder(@PathVariable Long groupId,
+                                               @RequestBody CreateOrderRequest request) {
         return orderService.registerOrder(groupId, request);
     }
 
-    @PostMapping("/{groupId}/joins/confirms")
-    public void completeClubJoinOrder(
-            @PathVariable Long groupId,
-            @RequestBody PaymentCompleteReqeust request) {
+    @PostMapping("/{groupId}/orders/confirm")
+    public void completeClubJoinOrder(@PathVariable Long groupId,
+                                      @RequestBody PaymentCompleteReqeust request) {
         orderService.confirmOrderPayment(groupId, request, LocalDate.now());
     }
 

--- a/src/main/java/woohakdong/server/api/controller/group/dto/GroupInfoResponse.java
+++ b/src/main/java/woohakdong/server/api/controller/group/dto/GroupInfoResponse.java
@@ -1,19 +1,18 @@
-package woohakdong.server.api.controller.club.dto;
+package woohakdong.server.api.controller.group.dto;
 
 import lombok.Builder;
 import woohakdong.server.domain.group.Group;
 
 @Builder
-public record ClubJoinGroupInfoResponse(
+public record GroupInfoResponse(
         Long groupId,
         String groupName,
         String groupJoinLink,
         String groupDescription,
         Integer groupAmount
 ) {
-
-    public static ClubJoinGroupInfoResponse from(Group group) {
-        return ClubJoinGroupInfoResponse.builder()
+    public static GroupInfoResponse from(Group group) {
+        return GroupInfoResponse.builder()
                 .groupId(group.getGroupId())
                 .groupName(group.getGroupName())
                 .groupJoinLink(group.getGroupJoinLink())

--- a/src/main/java/woohakdong/server/api/controller/group/dto/PortOneWebhookRequest.java
+++ b/src/main/java/woohakdong/server/api/controller/group/dto/PortOneWebhookRequest.java
@@ -1,11 +1,16 @@
 package woohakdong.server.api.controller.group.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record PortOneWebhookRequest(
+        @NotNull @JsonProperty("merchant_uid")
         String merchantUid,
+        @NotNull @JsonProperty("imp_uid")
         String impUid,
+        @NotNull
         String status
 ) {
 }

--- a/src/main/java/woohakdong/server/api/controller/item/ItemController.java
+++ b/src/main/java/woohakdong/server/api/controller/item/ItemController.java
@@ -1,9 +1,29 @@
 package woohakdong.server.api.controller.item;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import woohakdong.server.api.controller.ListWrapperResponse;
-import woohakdong.server.api.controller.item.dto.*;
+import woohakdong.server.api.controller.item.dto.ItemAvailableUpdateRequest;
+import woohakdong.server.api.controller.item.dto.ItemBorrowResponse;
+import woohakdong.server.api.controller.item.dto.ItemBorrowedResponse;
+import woohakdong.server.api.controller.item.dto.ItemHistoryResponse;
+import woohakdong.server.api.controller.item.dto.ItemInfoResponse;
+import woohakdong.server.api.controller.item.dto.ItemRegisterRequest;
+import woohakdong.server.api.controller.item.dto.ItemRegisterResponse;
+import woohakdong.server.api.controller.item.dto.ItemResponse;
+import woohakdong.server.api.controller.item.dto.ItemReturnRequest;
+import woohakdong.server.api.controller.item.dto.ItemReturnResponse;
+import woohakdong.server.api.controller.item.dto.ItemUpdateRequest;
+import woohakdong.server.api.controller.item.dto.ItemUpdateResponse;
 import woohakdong.server.api.service.item.ItemService;
 
 
@@ -26,7 +46,8 @@ public class ItemController implements ItemControllerDocs {
                                                       @RequestParam(required = false) Boolean using,
                                                       @RequestParam(required = false) Boolean available,
                                                       @RequestParam(required = false) Boolean overdue) {
-        return ListWrapperResponse.of(itemService.getItemsByFilters(clubId, keyword, category, using, available, overdue));
+        return ListWrapperResponse.of(
+                itemService.getItemsByFilters(clubId, keyword, category, using, available, overdue));
     }
 
     @GetMapping("/{clubId}/items/{itemId}")
@@ -36,13 +57,13 @@ public class ItemController implements ItemControllerDocs {
 
     @PostMapping("/{clubId}/items/{itemId}/borrow")
     public ItemBorrowResponse borrowItem(@PathVariable Long clubId, @PathVariable Long itemId) {
-        return itemService.borrowItem(clubId, itemId);
+        return itemService.borrowItem(clubId, itemId, LocalDate.now());
     }
 
     @PostMapping("/{clubId}/items/{itemId}/return")
     public ItemReturnResponse returnItem(@PathVariable Long clubId, @PathVariable Long itemId,
                                          @RequestBody ItemReturnRequest request) {
-        return itemService.returnItem(clubId, itemId, request);
+        return itemService.returnItem(clubId, itemId, request, LocalDate.now());
     }
 
     @GetMapping("/{clubId}/items/{itemId}/history")
@@ -71,16 +92,17 @@ public class ItemController implements ItemControllerDocs {
 
     @GetMapping("/{clubId}/items/borrowed")
     public ListWrapperResponse<ItemBorrowedResponse> getMyBorrowedItems(@PathVariable Long clubId) {
-        return ListWrapperResponse.of(itemService.getMyBorrowedItems(clubId));
+        return ListWrapperResponse.of(itemService.getMyBorrowedItems(clubId, LocalDate.now()));
     }
 
     @GetMapping("/{clubId}/items/history")
     public ListWrapperResponse<ItemHistoryResponse> getMyHistoryItems(@PathVariable Long clubId) {
-        return ListWrapperResponse.of(itemService.getMyHistoryItems(clubId));
+        return ListWrapperResponse.of(itemService.getMyHistoryItems(clubId, LocalDate.now()));
     }
 
     @GetMapping("/{clubId}/items/history/{clubMemberId}")
-    public ListWrapperResponse<ItemHistoryResponse> getClubMemberHistoryItems(@PathVariable Long clubId, @PathVariable Long clubMemberId) {
+    public ListWrapperResponse<ItemHistoryResponse> getClubMemberHistoryItems(@PathVariable Long clubId,
+                                                                              @PathVariable Long clubMemberId) {
         return ListWrapperResponse.of(itemService.getClubMemberHistoryItems(clubId, clubMemberId));
     }
 }

--- a/src/main/java/woohakdong/server/api/controller/notification/NotificationController.java
+++ b/src/main/java/woohakdong/server/api/controller/notification/NotificationController.java
@@ -17,13 +17,13 @@ public class NotificationController implements NotificationControllerDocs {
 
     @PostMapping("/clubs")
     public void sendNotificationWithClubInfoUpdate(@PathVariable Long clubId) {
-        notificationService.sendNotificationWithClubInfoUpdate(clubId, getAssignedTerm());
+        notificationService.sendNotificationWithClubInfoUpdate(clubId, LocalDate.now());
     }
 
     @PostMapping("/schedules/{scheduleId}")
     public void sendNotificationWithSchedule(@PathVariable Long clubId,
                                              @PathVariable Long scheduleId) {
-        notificationService.sendNotificationWithSchedule(clubId, scheduleId, getAssignedTerm());
+        notificationService.sendNotificationWithSchedule(clubId, scheduleId, LocalDate.now());
     }
 
     @PostMapping("/groups/{groupId}")
@@ -32,10 +32,5 @@ public class NotificationController implements NotificationControllerDocs {
 
     }
 
-    private LocalDate getAssignedTerm() {
-        LocalDate now = LocalDate.now();
-        int year = now.getYear();
-        int semester = now.getMonthValue() <= 6 ? 1 : 7; // 1: 1학기, 7: 2학기
-        return LocalDate.of(year, semester, 1);
-    }
+
 }

--- a/src/main/java/woohakdong/server/api/service/admin/auth/AdminAuthService.java
+++ b/src/main/java/woohakdong/server/api/service/admin/auth/AdminAuthService.java
@@ -1,8 +1,10 @@
 package woohakdong.server.api.service.admin.auth;
 
+import static woohakdong.server.common.exception.CustomErrorInfo.ADMIN_USERNAME_IS_ALREADY_USED;
+import static woohakdong.server.common.exception.CustomErrorInfo.INVALID_ADMIN_PASSWORD;
+
+import java.util.Date;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,27 +14,24 @@ import woohakdong.server.api.controller.admin.auth.dto.AdminJoinRequest;
 import woohakdong.server.api.controller.admin.auth.dto.AdminLoginRequest;
 import woohakdong.server.api.controller.auth.dto.LoginResponse;
 import woohakdong.server.common.exception.CustomException;
-import woohakdong.server.common.security.jwt.CustomUserDetails;
 import woohakdong.server.common.security.jwt.JWTUtil;
+import woohakdong.server.common.util.security.SecurityUtil;
 import woohakdong.server.domain.member.Member;
 import woohakdong.server.domain.member.MemberRepository;
-import woohakdong.server.domain.member.MemberRepositoryImpl;
 import woohakdong.server.domain.refreshToken.RefreshToken;
 import woohakdong.server.domain.refreshToken.RefreshTokenRepository;
-
-import java.util.Date;
-
-import static woohakdong.server.common.exception.CustomErrorInfo.*;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AdminAuthService {
 
+    private final JWTUtil jwtUtil;
+    private final SecurityUtil securityUtil;
+    private final BCryptPasswordEncoder passwordEncoder;
+
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
-    private final JWTUtil jwtUtil;
-    private final BCryptPasswordEncoder passwordEncoder;
 
     @Transactional
     public LoginResponse login(AdminLoginRequest loginRequest) {
@@ -66,38 +65,27 @@ public class AdminAuthService {
 
     @Transactional
     public void updateAdmin(AdminInfoUpdateRequest updateRequest) {
-        Member admin = getMemberFromJwtInformation();
+        Member admin = securityUtil.getMember();
 
         if (memberRepository.findByMemberProvideId(updateRequest.memberLoginId()).isPresent()) {
             throw new CustomException(ADMIN_USERNAME_IS_ALREADY_USED);
         }
 
         String encryptedPassword = passwordEncoder.encode(updateRequest.memberPassword());
-
-        admin.adminUpdate(updateRequest.memberLoginId(), updateRequest.memberName(), updateRequest.memberEmail(), encryptedPassword);
+        admin.adminUpdate(updateRequest.memberLoginId(), updateRequest.memberName(), updateRequest.memberEmail(),
+                encryptedPassword);
 
         memberRepository.save(admin);
     }
 
     public AdminInfoResponse getAdminInfo() {
-        Member admin = getMemberFromJwtInformation();
-
+        Member admin = securityUtil.getMember();
         return AdminInfoResponse.from(admin);
     }
 
     private void addRefreshEntity(String provideId, String refresh, Long expiredMs) {
-
         Date date = new Date(System.currentTimeMillis() + expiredMs);
         RefreshToken refreshToken = RefreshToken.create(provideId, refresh, date.toString());
         refreshTokenRepository.save(refreshToken);
-    }
-
-    private Member getMemberFromJwtInformation() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        String provideId = userDetails.getUsername();
-
-        return memberRepository.findByMemberProvideId(provideId)
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/woohakdong/server/api/service/club/ClubService.java
+++ b/src/main/java/woohakdong/server/api/service/club/ClubService.java
@@ -10,6 +10,8 @@ import static woohakdong.server.domain.group.GroupType.JOIN;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -137,8 +139,11 @@ public class ClubService {
         Member member = securityUtil.getMember();
         List<ClubMember> clubMembers = clubMemberRepository.getAllByMember(member);
 
-        return clubMembers.stream()
+        Set<Club> clubs = clubMembers.stream()
                 .map(ClubMember::getClub)
+                .collect(Collectors.toSet());
+
+        return clubs.stream()
                 .map(ClubInfoResponse::from)
                 .toList();
     }

--- a/src/main/java/woohakdong/server/api/service/club/ClubService.java
+++ b/src/main/java/woohakdong/server/api/service/club/ClubService.java
@@ -9,6 +9,7 @@ import static woohakdong.server.domain.group.GroupType.CLUB_PAYMENT;
 import static woohakdong.server.domain.group.GroupType.JOIN;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -139,11 +140,10 @@ public class ClubService {
         Member member = securityUtil.getMember();
         List<ClubMember> clubMembers = clubMemberRepository.getAllByMember(member);
 
-        Set<Club> clubs = clubMembers.stream()
+        return clubMembers.stream()
                 .map(ClubMember::getClub)
-                .collect(Collectors.toSet());
-
-        return clubs.stream()
+                .distinct() // 중복 제거
+                .sorted(Comparator.comparing(Club::getClubId)) // clubId로 정렬
                 .map(ClubInfoResponse::from)
                 .toList();
     }

--- a/src/main/java/woohakdong/server/api/service/club/ClubService.java
+++ b/src/main/java/woohakdong/server/api/service/club/ClubService.java
@@ -160,7 +160,7 @@ public class ClubService {
         return ClubInfoResponse.from(club);
     }
 
-    @Transactional
+    @Transactional(noRollbackFor = CustomException.class)
     public void checkClubExpired(Long clubId, LocalDate date) {
         Club club = clubRepository.getById(clubId);
         LocalDate assignedTerm = getAssignedTerm(date).minusMonths(6);

--- a/src/main/java/woohakdong/server/api/service/club/ClubService.java
+++ b/src/main/java/woohakdong/server/api/service/club/ClubService.java
@@ -65,20 +65,21 @@ public class ClubService {
     public ClubIdResponse registerClub(ClubCreateRequest request, LocalDate date) {
         Member member = securityUtil.getMember();
         School school = member.getSchool();
+        LocalDate assignedTerm = dateUtil.getAssignedTerm(date);
 
         validateClubWithNames(request.clubName(), request.clubEnglishName());
 
         Club club = Club.create(request.clubName(), request.clubEnglishName(), request.clubDescription(),
                 request.clubImage(), request.clubRoom(), request.clubGeneration(), request.clubDues(),
-                request.clubGroupChatLink(), request.clubGroupChatPassword(), school);
+                request.clubGroupChatLink(), request.clubGroupChatPassword(), assignedTerm, school);
 
         Group group = Group.create(club.getClubName(),
                 club.getClubName() + "의 " + club.getClubGeneration() + "기 동아리 가입하기", club.getClubDues(),
                 WOOHAKDONG_CLUB_PREFIX + club.getClubEnglishName(), club.getClubGroupChatLink(),
                 club.getClubGroupChatPassword(), JOIN, club);
 
-        ClubMember clubMember = ClubMember.create(club, dateUtil.getAssignedTerm(date), PRESIDENT, member);
-        ClubHistory clubHistory = ClubHistory.create(club, dateUtil.getAssignedTerm(date));
+        ClubMember clubMember = ClubMember.create(club, assignedTerm, PRESIDENT, member);
+        ClubHistory clubHistory = ClubHistory.create(club, assignedTerm);
 
         club.addGroup(group);
         club.addClubMember(clubMember);

--- a/src/main/java/woohakdong/server/api/service/club/ClubService.java
+++ b/src/main/java/woohakdong/server/api/service/club/ClubService.java
@@ -6,6 +6,7 @@ import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_NAME_DUPLI
 import static woohakdong.server.common.exception.CustomErrorInfo.INVALID_BANK_NAME;
 import static woohakdong.server.common.exception.CustomErrorInfo.MEMBER_NOT_FOUND;
 import static woohakdong.server.domain.clubmember.ClubMemberRole.PRESIDENT;
+import static woohakdong.server.domain.group.GroupType.CLUB_PAYMENT;
 import static woohakdong.server.domain.group.GroupType.JOIN;
 
 import java.time.LocalDate;
@@ -22,9 +23,9 @@ import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
 import woohakdong.server.api.controller.club.dto.ClubHistoryTermResponse;
 import woohakdong.server.api.controller.club.dto.ClubIdResponse;
 import woohakdong.server.api.controller.club.dto.ClubInfoResponse;
-import woohakdong.server.api.controller.club.dto.ClubJoinGroupInfoResponse;
 import woohakdong.server.api.controller.club.dto.ClubSummaryResponse;
 import woohakdong.server.api.controller.club.dto.ClubUpdateRequest;
+import woohakdong.server.api.controller.group.dto.GroupInfoResponse;
 import woohakdong.server.common.exception.CustomException;
 import woohakdong.server.common.security.jwt.CustomUserDetails;
 import woohakdong.server.domain.club.Club;
@@ -119,11 +120,11 @@ public class ClubService {
                 .toList();
     }
 
-    public ClubJoinGroupInfoResponse getClubJoinInfo(Long clubId) {
+    public GroupInfoResponse getClubJoinInfo(Long clubId) {
         Club club = clubRepository.getById(clubId);
         Group group = groupRepository.getByClubAndGroupType(club, JOIN);
 
-        return ClubJoinGroupInfoResponse.from(group);
+        return GroupInfoResponse.from(group);
     }
 
     public List<ClubInfoResponse> getJoinedClubInfos() {
@@ -172,6 +173,11 @@ public class ClubService {
         }
     }
 
+    public GroupInfoResponse getGroupPaymentInfo(Long clubId) {
+        Club club = clubRepository.getById(clubId);
+        Group group = groupRepository.getByClubAndGroupType(club, CLUB_PAYMENT);
+        return GroupInfoResponse.from(group);
+    }
 
     private Member getMemberFromJwtInformation() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -181,7 +187,6 @@ public class ClubService {
         return memberRepository.findByMemberProvideId(provideId)
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
     }
-
 
     private LocalDate getAssignedTerm(LocalDate now) {
         int year = now.getYear();

--- a/src/main/java/woohakdong/server/api/service/club/ClubService.java
+++ b/src/main/java/woohakdong/server/api/service/club/ClubService.java
@@ -65,13 +65,14 @@ public class ClubService {
     public ClubIdResponse registerClub(ClubCreateRequest request, LocalDate date) {
         Member member = securityUtil.getMember();
         School school = member.getSchool();
-        LocalDate assignedTerm = dateUtil.getAssignedTerm(date).plusMonths(6);
+        LocalDate assignedTerm = dateUtil.getAssignedTerm(date);
+        LocalDate expirationDate = assignedTerm.plusMonths(6).minusDays(1);
 
         validateClubWithNames(request.clubName(), request.clubEnglishName());
 
         Club club = Club.create(request.clubName(), request.clubEnglishName(), request.clubDescription(),
                 request.clubImage(), request.clubRoom(), request.clubGeneration(), request.clubDues(),
-                request.clubGroupChatLink(), request.clubGroupChatPassword(), assignedTerm, school);
+                request.clubGroupChatLink(), request.clubGroupChatPassword(), expirationDate, school);
 
         String groupDescription = club.getClubName() + "신규 가입";
         if (groupDescription.length() > 15) {

--- a/src/main/java/woohakdong/server/api/service/club/ClubService.java
+++ b/src/main/java/woohakdong/server/api/service/club/ClubService.java
@@ -168,8 +168,10 @@ public class ClubService {
         Integer clubMemberNumber = clubMemberRepository.countByClubAndAssignedTerm(club, assignedTerm);
 
         if (club.isExpired(date)) {
-            Group group = Group.createClubPaymentGroup(club, clubMemberNumber);
-            club.addGroup(group);
+            if ( !groupRepository.checkExistenceClubGroup(club, CLUB_PAYMENT)) {
+                Group group = Group.createClubPaymentGroup(club, clubMemberNumber);
+                club.addGroup(group);
+            }
             throw new CustomException(CLUB_EXPIRED);
         }
     }

--- a/src/main/java/woohakdong/server/api/service/clubMember/ClubMemberService.java
+++ b/src/main/java/woohakdong/server/api/service/clubMember/ClubMemberService.java
@@ -58,12 +58,13 @@ public class ClubMemberService {
     }
 
     @Transactional
-    public void changeClubMemberRole(Long clubId, Long clubMemberId, ClubMemberRole clubMemberRole) {
+    public void changeClubMemberRole(Long clubId, Long clubMemberId, ClubMemberRole clubMemberRole, LocalDate date) {
         Member member = securityUtil.getMember();
         Club club = clubRepository.getById(clubId);
-        ClubMember requestMember = clubMemberRepository.getByClubAndMember(club, member);
+        LocalDate assignedTerm = dateUtil.getAssignedTerm(date);
+        ClubMember president = clubMemberRepository.getByClubAndMemberAndAssignedTerm(club, member, assignedTerm);
 
-        if (!requestMember.getClubMemberRole().equals(ClubMemberRole.PRESIDENT)) {
+        if (!president.getClubMemberRole().equals(ClubMemberRole.PRESIDENT)) {
             throw new CustomException(CLUB_MEMBER_ROLE_NOT_ALLOWED);
         }
 

--- a/src/main/java/woohakdong/server/api/service/clubMember/ClubMemberService.java
+++ b/src/main/java/woohakdong/server/api/service/clubMember/ClubMemberService.java
@@ -1,34 +1,31 @@
 package woohakdong.server.api.service.clubMember;
 
 import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_MEMBER_ROLE_NOT_ALLOWED;
-import static woohakdong.server.common.exception.CustomErrorInfo.MEMBER_NOT_FOUND;
 
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.api.controller.clubMember.dto.ClubMemberInfoResponse;
 import woohakdong.server.common.exception.CustomException;
-import woohakdong.server.common.security.jwt.CustomUserDetails;
+import woohakdong.server.common.util.security.SecurityUtil;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
 import woohakdong.server.domain.clubmember.ClubMember;
 import woohakdong.server.domain.clubmember.ClubMemberRepository;
 import woohakdong.server.domain.clubmember.ClubMemberRole;
 import woohakdong.server.domain.member.Member;
-import woohakdong.server.domain.member.MemberRepository;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ClubMemberService {
 
+    private final SecurityUtil securityUtil;
+
     private final ClubMemberRepository clubMemberRepository;
     private final ClubRepository clubRepository;
-    private final MemberRepository memberRepository;
 
     public List<ClubMemberInfoResponse> getMembers(Long clubId) {
         Club club = clubRepository.getById(clubId);
@@ -49,7 +46,7 @@ public class ClubMemberService {
     }
 
     public ClubMemberInfoResponse getMyInfo(Long clubId) {
-        Member member = getMemberFromJwtInformation();
+        Member member = securityUtil.getMember();
         Club club = clubRepository.getById(clubId);
         LocalDate assignedTerm = getAssignedTerm();
 
@@ -60,7 +57,7 @@ public class ClubMemberService {
 
     @Transactional
     public void changeClubMemberRole(Long clubId, Long clubMemberId, ClubMemberRole clubMemberRole) {
-        Member member = getMemberFromJwtInformation();
+        Member member = securityUtil.getMember();
         Club club = clubRepository.getById(clubId);
         ClubMember requestMember = clubMemberRepository.getByClubAndMember(club, member);
 
@@ -87,14 +84,5 @@ public class ClubMemberService {
         int year = now.getYear();
         int semester = now.getMonthValue() <= 6 ? 1 : 7; // 1: 1학기, 7: 2학기
         return LocalDate.of(year, semester, 1);
-    }
-
-    private Member getMemberFromJwtInformation() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        String provideId = userDetails.getUsername();
-
-        return memberRepository.findByMemberProvideId(provideId)
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/woohakdong/server/api/service/notification/NotificationService.java
+++ b/src/main/java/woohakdong/server/api/service/notification/NotificationService.java
@@ -1,19 +1,16 @@
 package woohakdong.server.api.service.notification;
 
-import static woohakdong.server.common.exception.CustomErrorInfo.MEMBER_NOT_FOUND;
+import static woohakdong.server.domain.clubmember.ClubMemberRole.PRESIDENT;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.api.service.email.EmailService;
-import woohakdong.server.common.exception.CustomException;
-import woohakdong.server.common.security.jwt.CustomUserDetails;
+import woohakdong.server.common.util.security.SecurityUtil;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
 import woohakdong.server.domain.clubmember.ClubMember;
@@ -21,7 +18,6 @@ import woohakdong.server.domain.clubmember.ClubMemberRepository;
 import woohakdong.server.domain.itemBorrowed.ItemBorrowed;
 import woohakdong.server.domain.itemBorrowed.ItemBorrowedRepository;
 import woohakdong.server.domain.member.Member;
-import woohakdong.server.domain.member.MemberRepository;
 import woohakdong.server.domain.schedule.Schedule;
 import woohakdong.server.domain.schedule.ScheduleRepository;
 
@@ -33,23 +29,23 @@ public class NotificationService {
     public static final DateTimeFormatter YEAR_MONTH_DAY_HOUR = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분");
 
     private final EmailService emailService;
+    private final SecurityUtil securityUtil;
 
     private final ClubRepository clubRepository;
     private final ScheduleRepository scheduleRepository;
     private final ClubMemberRepository clubMemberRepository;
-    private final MemberRepository memberRepository;
     private final ItemBorrowedRepository itemBorrowedRepository;
 
     public void sendNotificationWithClubInfoUpdate(Long clubId, LocalDate assignedTerm) {
-        getMemberFromJwtInformation(); // TODO : 임원 체크
         Club club = clubRepository.getById(clubId);
+        checkMemberRoleInClub(club);
         List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null, assignedTerm);
 
         clubMembers.stream()
                 .map(ClubMember::getMember)
-                .forEach(member -> emailService.sendEmailForUpdateClubInfo(
-                        member.getMemberName(),
-                        member.getMemberEmail(),
+                .forEach(m -> emailService.sendEmailForUpdateClubInfo(
+                        m.getMemberName(),
+                        m.getMemberEmail(),
                         club.getClubName(),
                         club.getClubDescription(),
                         club.getClubGroupChatLink(),
@@ -58,17 +54,17 @@ public class NotificationService {
     }
 
     public void sendNotificationWithSchedule(Long clubId, Long scheduleId, LocalDate assignedTerm) {
-        getMemberFromJwtInformation(); // TODO : 임원 체크
         Club club = clubRepository.getById(clubId);
+        checkMemberRoleInClub(club);
         List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null, assignedTerm);
         Schedule schedule = scheduleRepository.getById(scheduleId);
         String scheduleDate = schedule.getScheduleDateTime().format(YEAR_MONTH_DAY_HOUR);
 
         clubMembers.stream()
                 .map(ClubMember::getMember)
-                .forEach(member -> emailService.sendEmailForSchedule(
-                        member.getMemberName(),
-                        member.getMemberEmail(),
+                .forEach(m -> emailService.sendEmailForSchedule(
+                        m.getMemberName(),
+                        m.getMemberEmail(),
                         club.getClubName(),
                         schedule.getScheduleTitle(),
                         schedule.getScheduleContent(),
@@ -81,22 +77,18 @@ public class NotificationService {
         LocalDateTime now = LocalDateTime.now();
         List<ItemBorrowed> overdueItems = itemBorrowedRepository.getByItemBorrowedReturnDateBefore(now);
 
-        overdueItems.stream()
-                .forEach(itemBorrowed -> emailService.sendOverdueNotification(
-                        itemBorrowed.getClubMember().getMember().getMemberName(),
-                        itemBorrowed.getClubMember().getMember().getMemberEmail(),
-                        itemBorrowed.getItem().getItemName(),
-                        itemBorrowed.getItem().getClub().getClubName(),
-                        itemBorrowed.getItemBorrowedReturnDate().toString()
-                ));
+        overdueItems.forEach(itemBorrowed -> emailService.sendOverdueNotification(
+                itemBorrowed.getClubMember().getMember().getMemberName(),
+                itemBorrowed.getClubMember().getMember().getMemberEmail(),
+                itemBorrowed.getItem().getItemName(),
+                itemBorrowed.getItem().getClub().getClubName(),
+                itemBorrowed.getItemBorrowedReturnDate().toString()
+        ));
     }
 
-    private Member getMemberFromJwtInformation() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        String provideId = userDetails.getUsername();
-
-        return memberRepository.findByMemberProvideId(provideId)
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+    private void checkMemberRoleInClub(Club club) {
+        Member member = securityUtil.getMember();
+        ClubMember clubMember = clubMemberRepository.getByClubAndMember(club, member);
+        clubMember.hasAuthorityOf(PRESIDENT);
     }
 }

--- a/src/main/java/woohakdong/server/api/service/notification/NotificationService.java
+++ b/src/main/java/woohakdong/server/api/service/notification/NotificationService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.api.service.email.EmailService;
+import woohakdong.server.common.util.date.DateUtil;
 import woohakdong.server.common.util.security.SecurityUtil;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
@@ -30,16 +31,18 @@ public class NotificationService {
 
     private final EmailService emailService;
     private final SecurityUtil securityUtil;
+    private final DateUtil dateUtil;
 
     private final ClubRepository clubRepository;
     private final ScheduleRepository scheduleRepository;
     private final ClubMemberRepository clubMemberRepository;
     private final ItemBorrowedRepository itemBorrowedRepository;
 
-    public void sendNotificationWithClubInfoUpdate(Long clubId, LocalDate assignedTerm) {
+    public void sendNotificationWithClubInfoUpdate(Long clubId, LocalDate date) {
         Club club = clubRepository.getById(clubId);
         checkMemberRoleInClub(club);
-        List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null, assignedTerm);
+        List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null,
+                dateUtil.getAssignedTerm(date));
 
         clubMembers.stream()
                 .map(ClubMember::getMember)
@@ -53,10 +56,11 @@ public class NotificationService {
                 ));
     }
 
-    public void sendNotificationWithSchedule(Long clubId, Long scheduleId, LocalDate assignedTerm) {
+    public void sendNotificationWithSchedule(Long clubId, Long scheduleId, LocalDate date) {
         Club club = clubRepository.getById(clubId);
         checkMemberRoleInClub(club);
-        List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null, assignedTerm);
+        List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null,
+                dateUtil.getAssignedTerm(date));
         Schedule schedule = scheduleRepository.getById(scheduleId);
         String scheduleDate = schedule.getScheduleDateTime().format(YEAR_MONTH_DAY_HOUR);
 

--- a/src/main/java/woohakdong/server/api/service/notification/NotificationService.java
+++ b/src/main/java/woohakdong/server/api/service/notification/NotificationService.java
@@ -40,9 +40,9 @@ public class NotificationService {
 
     public void sendNotificationWithClubInfoUpdate(Long clubId, LocalDate date) {
         Club club = clubRepository.getById(clubId);
-        checkMemberRoleInClub(club);
-        List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null,
-                dateUtil.getAssignedTerm(date));
+        LocalDate assignedTerm = dateUtil.getAssignedTerm(date);
+        checkMemberRoleInClub(club, assignedTerm);
+        List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null, assignedTerm);
 
         clubMembers.stream()
                 .map(ClubMember::getMember)
@@ -58,9 +58,9 @@ public class NotificationService {
 
     public void sendNotificationWithSchedule(Long clubId, Long scheduleId, LocalDate date) {
         Club club = clubRepository.getById(clubId);
-        checkMemberRoleInClub(club);
-        List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null,
-                dateUtil.getAssignedTerm(date));
+        LocalDate assignedTerm = dateUtil.getAssignedTerm(date);
+        checkMemberRoleInClub(club, assignedTerm);
+        List<ClubMember> clubMembers = clubMemberRepository.getAllBySearchFilter(club, null, assignedTerm);
         Schedule schedule = scheduleRepository.getById(scheduleId);
         String scheduleDate = schedule.getScheduleDateTime().format(YEAR_MONTH_DAY_HOUR);
 
@@ -90,9 +90,9 @@ public class NotificationService {
         ));
     }
 
-    private void checkMemberRoleInClub(Club club) {
+    private void checkMemberRoleInClub(Club club, LocalDate assignedTerm) {
         Member member = securityUtil.getMember();
-        ClubMember clubMember = clubMemberRepository.getByClubAndMember(club, member);
+        ClubMember clubMember = clubMemberRepository.getByClubAndMemberAndAssignedTerm(club, member, assignedTerm);
         clubMember.hasAuthorityOf(PRESIDENT);
     }
 }

--- a/src/main/java/woohakdong/server/api/service/order/OrderService.java
+++ b/src/main/java/woohakdong/server/api/service/order/OrderService.java
@@ -108,8 +108,16 @@ public class OrderService {
         if (group.isTypeOf(CLUB_PAYMENT)) {
             club.extendClubExpirationDate();
             LocalDate expirationDate = club.getClubExpirationDate();
-            ClubHistory clubHistory = ClubHistory.create(club, expirationDate.plusMonths(6));
+            LocalDate newAssignedTerm = expirationDate.plusDays(1);
+            LocalDate pastAssignedTerm = newAssignedTerm.minusMonths(6);
+
+            ClubHistory clubHistory = ClubHistory.create(club, newAssignedTerm);
             clubHistoryRepository.save(clubHistory);
+
+            ClubMember clubMember = clubMemberRepository.getByClubAndMemberAndAssignedTerm(club, member,
+                    pastAssignedTerm);
+            ClubMember newPresident = ClubMember.createFromExisting(clubMember, newAssignedTerm);
+            clubMemberRepository.save(newPresident);
         }
 
     }
@@ -142,8 +150,16 @@ public class OrderService {
         if (group.isTypeOf(CLUB_PAYMENT)) {
             club.extendClubExpirationDate();
             LocalDate expirationDate = club.getClubExpirationDate();
-            ClubHistory clubHistory = ClubHistory.create(club, expirationDate.plusMonths(6));
+            LocalDate newAssignedTerm = expirationDate.plusDays(1);
+            LocalDate pastAssignedTerm = newAssignedTerm.minusMonths(6);
+
+            ClubHistory clubHistory = ClubHistory.create(club, newAssignedTerm);
             clubHistoryRepository.save(clubHistory);
+
+            ClubMember clubMember = clubMemberRepository.getByClubAndMemberAndAssignedTerm(club, member,
+                    pastAssignedTerm);
+            ClubMember newPresident = ClubMember.createFromExisting(clubMember, newAssignedTerm);
+            clubMemberRepository.save(newPresident);
         }
     }
 
@@ -176,10 +192,6 @@ public class OrderService {
             // TODO : 이벤트 그룹 가입 여부 확인
             throw new CustomException(CLUB_GROUP_ALREADY_JOINED);
         }
-    }
-
-    protected void savePaymentFromOrder(PaymentInfoResponse response, Order order) {
-
     }
 
     protected void saveNewClubMember(Club group, Member member, LocalDate date) {

--- a/src/main/java/woohakdong/server/api/service/order/OrderService.java
+++ b/src/main/java/woohakdong/server/api/service/order/OrderService.java
@@ -92,8 +92,11 @@ public class OrderService {
 
         Club club = group.getClub();
 
-        PaymentInfoResponse paymentInfoResponse = checkOrderWithPaymentClient(request.impUid(), order);
-        savePaymentFromOrder(paymentInfoResponse, order);
+        PaymentInfoResponse response = checkOrderWithPaymentClient(request.impUid(), order);
+        Payment payment = Payment.create(response.amount(), response.impUid(), response.merchantUid());
+        order.completeOrder(payment);
+        orderRepository.save(order);
+
         saveAdminAccount(order, group, member);
 
         if (group.isTypeOf(JOIN)) {
@@ -123,8 +126,11 @@ public class OrderService {
         Member member = order.getMember();
         Club club = group.getClub();
 
-        PaymentInfoResponse paymentInfoResponse = checkOrderWithPaymentClient(request.impUid(), order);
-        savePaymentFromOrder(paymentInfoResponse, order);
+        PaymentInfoResponse response = checkOrderWithPaymentClient(request.impUid(), order);
+        Payment payment = Payment.create(response.amount(), response.impUid(), response.merchantUid());
+        order.completeOrder(payment);
+        orderRepository.save(order);
+
         saveAdminAccount(order, group, member);
 
         if (group.isTypeOf(JOIN)) {
@@ -173,8 +179,7 @@ public class OrderService {
     }
 
     protected void savePaymentFromOrder(PaymentInfoResponse response, Order order) {
-        Payment payment = Payment.create(response.amount(), response.impUid(), response.merchantUid());
-        order.completeOrder(payment);
+
     }
 
     protected void saveNewClubMember(Club group, Member member, LocalDate date) {

--- a/src/main/java/woohakdong/server/api/service/order/OrderService.java
+++ b/src/main/java/woohakdong/server/api/service/order/OrderService.java
@@ -24,6 +24,7 @@ import woohakdong.server.api.controller.group.dto.PortOneWebhookRequest;
 import woohakdong.server.api.service.bank.MockBankService;
 import woohakdong.server.api.service.email.EmailService;
 import woohakdong.server.common.exception.CustomException;
+import woohakdong.server.common.util.date.DateUtil;
 import woohakdong.server.common.util.security.SecurityUtil;
 import woohakdong.server.domain.admin.adminAccount.AdminAccount;
 import woohakdong.server.domain.admin.adminAccount.AdminAccountRepository;
@@ -49,6 +50,7 @@ public class OrderService {
     private final PaymentClient paymentClient;
 
     private final SecurityUtil securityUtil;
+    private final DateUtil dateUtil;
 
     private final ClubMemberRepository clubMemberRepository;
     private final GroupRepository groupRepository;
@@ -166,8 +168,8 @@ public class OrderService {
         order.completeOrder(payment);
     }
 
-    protected void saveNewClubMember(Club group, Member member, LocalDate now) {
-        ClubMember clubMember = ClubMember.create(group, getAssignedTerm(now), MEMBER, member);
+    protected void saveNewClubMember(Club group, Member member, LocalDate date) {
+        ClubMember clubMember = ClubMember.create(group, dateUtil.getAssignedTerm(date), MEMBER, member);
         clubMemberRepository.save(clubMember);
     }
 
@@ -191,9 +193,4 @@ public class OrderService {
         adminAccountRepository.save(adminAccount);
     }
 
-    private LocalDate getAssignedTerm(LocalDate now) {
-        int year = now.getYear();
-        int semester = now.getMonthValue() <= 6 ? 1 : 7; // 1: 1학기, 7: 2학기
-        return LocalDate.of(year, semester, 1);
-    }
 }

--- a/src/main/java/woohakdong/server/common/exception/CustomErrorInfo.java
+++ b/src/main/java/woohakdong/server/common/exception/CustomErrorInfo.java
@@ -42,7 +42,8 @@ public enum CustomErrorInfo {
     ITEM_BORROWED_NOT_FOUND(400, "item borrowed not found", 400034),
     CLUB_EXPIRED(400, "club expired", 400035),
     CLUB_NOT_EXPIRED(400, "club not expired", 400036),
-
+    MEMBER_ROLE_NOT_ADMIN(400, "member role is not admin", 400037),
+    CLUB_ADMIN_ROLE_NOT_ALLOWED(400, "club admin role not allowed", 400038),
 
     // 401 UNAUTHORIZED
     INVALID_ACCESS_TOKEN(401, "Invaild access token", 401001),

--- a/src/main/java/woohakdong/server/common/util/date/DateUtil.java
+++ b/src/main/java/woohakdong/server/common/util/date/DateUtil.java
@@ -1,0 +1,7 @@
+package woohakdong.server.common.util.date;
+
+import java.time.LocalDate;
+
+public interface DateUtil {
+    LocalDate getAssignedTerm(LocalDate date);
+}

--- a/src/main/java/woohakdong/server/common/util/date/DateUtilImpl.java
+++ b/src/main/java/woohakdong/server/common/util/date/DateUtilImpl.java
@@ -1,0 +1,27 @@
+package woohakdong.server.common.util.date;
+
+import java.time.LocalDate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DateUtilImpl implements DateUtil {
+
+    @Override
+    public LocalDate getAssignedTerm(LocalDate date) {
+        int year = date.getYear();
+        int month = date.getMonthValue();
+        int semester;
+        if (month >= 3 && month <= 8) {
+            // 1학기 : 3월 1일 ~ 8월 31일
+            semester = 3;
+        } else {
+            // 2학기 : 9월 1일 ~ 2월 28일
+            semester = 9;
+            if (month <= 2) {
+                // 2학기 2월 이전은 전년도 2학기
+                year--;
+            }
+        }
+        return LocalDate.of(year, semester, 1);
+    }
+}

--- a/src/main/java/woohakdong/server/common/util/security/SecurityUtil.java
+++ b/src/main/java/woohakdong/server/common/util/security/SecurityUtil.java
@@ -1,0 +1,9 @@
+package woohakdong.server.common.util.security;
+
+import woohakdong.server.domain.member.Member;
+
+public interface SecurityUtil {
+
+    Member getMember();
+    void checkMemberIsAdmin();
+}

--- a/src/main/java/woohakdong/server/common/util/security/SecurityUtilImpl.java
+++ b/src/main/java/woohakdong/server/common/util/security/SecurityUtilImpl.java
@@ -1,0 +1,44 @@
+package woohakdong.server.common.util.security;
+
+import static woohakdong.server.common.exception.CustomErrorInfo.MEMBER_NOT_FOUND;
+import static woohakdong.server.common.exception.CustomErrorInfo.MEMBER_ROLE_NOT_ADMIN;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import woohakdong.server.common.exception.CustomErrorInfo;
+import woohakdong.server.common.exception.CustomException;
+import woohakdong.server.common.security.jwt.CustomUserDetails;
+import woohakdong.server.domain.member.Member;
+import woohakdong.server.domain.member.MemberRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityUtilImpl implements SecurityUtil {
+
+    private final MemberRepository memberRepository;
+
+    public Member getMember() {
+        String provideId = getMemberProvideIdFromSecurityContext();
+
+        return memberRepository.findByMemberProvideId(provideId)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+    }
+
+    public void checkMemberIsAdmin() {
+        String provideId = getMemberProvideIdFromSecurityContext();
+        Member member = memberRepository.findByMemberProvideId(provideId)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        if (!member.isAdmin()) {
+            throw new CustomException(MEMBER_ROLE_NOT_ADMIN);
+        }
+    }
+
+    private static String getMemberProvideIdFromSecurityContext() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getUsername();
+    }
+}

--- a/src/main/java/woohakdong/server/domain/club/Club.java
+++ b/src/main/java/woohakdong/server/domain/club/Club.java
@@ -134,4 +134,8 @@ public class Club extends BaseEntity {
     public boolean isExpired(LocalDate date) {
         return date.isAfter(clubExpirationDate);
     }
+
+    public void extendClubExpirationDate() {
+        this.clubExpirationDate = clubExpirationDate.plusMonths(6);
+    }
 }

--- a/src/main/java/woohakdong/server/domain/club/Club.java
+++ b/src/main/java/woohakdong/server/domain/club/Club.java
@@ -92,7 +92,7 @@ public class Club extends BaseEntity {
 
     public static Club create(String clubName, String clubEnglishName, String clubDescription, String clubImage,
                               String clubRoom, String clubGeneration, Integer clubDues, String clubGroupChatLink,
-                              String clubGroupChatPassword, School school) {
+                              String clubGroupChatPassword, LocalDate date, School school) {
         return Club.builder()
                 .clubDescription(clubDescription)
                 .clubEnglishName(clubEnglishName)
@@ -104,7 +104,7 @@ public class Club extends BaseEntity {
                 .clubGroupChatLink(clubGroupChatLink)
                 .clubGroupChatPassword(clubGroupChatPassword)
                 .school(school)
-                .clubExpirationDate(LocalDate.now().plusMonths(6))
+                .clubExpirationDate(date)
                 .build();
     }
 

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
@@ -1,5 +1,9 @@
 package woohakdong.server.domain.clubmember;
 
+import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_ADMIN_ROLE_NOT_ALLOWED;
+import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_MEMBER_ROLE_NOT_ALLOWED;
+import static woohakdong.server.domain.clubmember.ClubMemberRole.PRESIDENT;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,6 +19,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import woohakdong.server.common.exception.CustomException;
 import woohakdong.server.domain.BaseEntity;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.member.Member;
@@ -70,5 +75,11 @@ public class ClubMember extends BaseEntity {
 
     public void changeRole(ClubMemberRole clubMemberRole) {
         this.clubMemberRole = clubMemberRole;
+    }
+
+    public void hasAuthorityOf(ClubMemberRole role) {
+        if (!this.clubMemberRole.hasAuthorityOf(role)) {
+            throw new CustomException(CLUB_MEMBER_ROLE_NOT_ALLOWED);
+        }
     }
 }

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMember.java
@@ -1,8 +1,6 @@
 package woohakdong.server.domain.clubmember;
 
-import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_ADMIN_ROLE_NOT_ALLOWED;
 import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_MEMBER_ROLE_NOT_ALLOWED;
-import static woohakdong.server.domain.clubmember.ClubMemberRole.PRESIDENT;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,8 +40,6 @@ public class ClubMember extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ClubMemberRole clubMemberRole;
 
-    private String clubGeneration;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -54,7 +50,7 @@ public class ClubMember extends BaseEntity {
 
     @Builder
     public ClubMember(Club club, LocalDate clubJoinedDate, LocalDate clubMemberAssignedTerm,
-                       ClubMemberRole clubMemberRole, Member member) {
+                      ClubMemberRole clubMemberRole, Member member) {
         this.club = club;
         this.clubJoinedDate = clubJoinedDate;
         this.clubMemberAssignedTerm = clubMemberAssignedTerm;
@@ -69,6 +65,16 @@ public class ClubMember extends BaseEntity {
                 .clubMemberAssignedTerm(assignedTerm)
                 .clubMemberRole(clubMemberRole)
                 .member(member)
+                .build();
+    }
+
+    public static ClubMember createFromExisting(ClubMember clubMember, LocalDate assignedTerm) {
+        return ClubMember.builder()
+                .club(clubMember.getClub())
+                .clubJoinedDate(LocalDate.now())
+                .clubMemberAssignedTerm(assignedTerm)
+                .clubMemberRole(clubMember.getClubMemberRole())
+                .member(clubMember.getMember())
                 .build();
     }
 

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepository.java
@@ -10,8 +10,6 @@ public interface ClubMemberRepository {
 
     ClubMember getById(Long clubMemberId);
 
-    ClubMember getByClubAndMember(Club club, Member member);
-
     List<ClubMember> getAllByMember(Member member);
 
     List<ClubMember> getAll();

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryImpl.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryImpl.java
@@ -28,12 +28,6 @@ public class ClubMemberRepositoryImpl implements ClubMemberRepository {
     }
 
     @Override
-    public ClubMember getByClubAndMember(Club club, Member member) {
-        return clubMemberJpaRepository.findByClubAndMember(club, member)
-                .orElseThrow(() -> new CustomException(CLUB_MEMBER_NOT_FOUND));
-    }
-
-    @Override
     public List<ClubMember> getAllByMember(Member member) {
         return clubMemberJpaRepository.findAllByMember(member);
     }

--- a/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRole.java
+++ b/src/main/java/woohakdong/server/domain/clubmember/ClubMemberRole.java
@@ -5,12 +5,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ClubMemberRole {
 
-    PRESIDENT("회장"),
-    VICEPRESIDENT("부회장"),
-    SECRETARY("총무"),
-    OFFICER("임원"),
-    MEMBER("회원")
+    PRESIDENT("회장", 1),
+    VICEPRESIDENT("부회장", 2),
+    SECRETARY("총무", 3),
+    OFFICER("임원", 4),
+    MEMBER("회원", 5)
     ;
 
     private final String role;
+    private final int authority;
+
+    public boolean hasAuthorityOf(ClubMemberRole role) {
+        return this.authority <= role.authority;
+    }
 }

--- a/src/main/java/woohakdong/server/domain/group/Group.java
+++ b/src/main/java/woohakdong/server/domain/group/Group.java
@@ -88,9 +88,8 @@ public class Group extends BaseEntity {
     }
 
     public static Group createClubPaymentGroup(Club club, Integer clubMemberCount) {
-        System.out.println("clubMemberCount = " + clubMemberCount);
         return Group.builder()
-                .groupName(club.getClubName() + " 동아리의 우학동 서비스 사용료 결제")
+                .groupName((club.getClubName() + "의 우학동 서비스 사용료 결제").substring(0, 15))
                 .groupDescription(club.getClubName() + "동아리의 우학동 서비스 사용료는 " + clubMemberCount + " * 500원 입니다.")
                 .groupAmount(BASE_SERVICE_FEE + clubMemberCount * PER_MEMBER_FEE)
                 .groupJoinLink(null)
@@ -101,9 +100,7 @@ public class Group extends BaseEntity {
                 .build();
     }
 
-    public void updateJoinGroup(String groupDescription, Integer groupAmount, String groupChatLink,
-                                String groupChatPassword) {
-        this.groupDescription = groupDescription;
+    public void updateJoinGroup(Integer groupAmount, String groupChatLink, String groupChatPassword) {
         this.groupAmount = groupAmount;
         this.groupChatLink = groupChatLink;
         this.groupChatPassword = groupChatPassword;

--- a/src/main/java/woohakdong/server/domain/group/GroupJpaRepository.java
+++ b/src/main/java/woohakdong/server/domain/group/GroupJpaRepository.java
@@ -7,9 +7,9 @@ import woohakdong.server.domain.club.Club;
 
 public interface GroupJpaRepository extends JpaRepository<Group, Long> {
 
-    // JOIN에 해당하는 Gathering을 찾는 메소드
     Optional<Group> findByClubAndGroupType(Club club, GroupType groupType);
 
-    // Event에 해당하는 Gathering을 찾는 메소드
     List<Group> findAllByClubAndGroupType(Club club, GroupType groupType);
+
+    boolean existsByClubAndGroupType(Club club, GroupType groupType);
 }

--- a/src/main/java/woohakdong/server/domain/group/GroupRepository.java
+++ b/src/main/java/woohakdong/server/domain/group/GroupRepository.java
@@ -13,4 +13,6 @@ public interface GroupRepository {
     Group getByClubAndGroupType(Club club, GroupType groupType);
 
     List<Group> getAllByClubAndGroupType(Club club, GroupType groupType);
+
+    boolean checkExistenceClubGroup(Club club, GroupType groupType);
 }

--- a/src/main/java/woohakdong/server/domain/group/GroupRepositoryImpl.java
+++ b/src/main/java/woohakdong/server/domain/group/GroupRepositoryImpl.java
@@ -40,4 +40,9 @@ public class GroupRepositoryImpl implements GroupRepository {
     public List<Group> getAllByClubAndGroupType(Club club, GroupType groupType) {
         return groupJpaRepository.findAllByClubAndGroupType(club, groupType);
     }
+
+    @Override
+    public boolean checkExistenceClubGroup(Club club, GroupType groupType) {
+        return groupJpaRepository.existsByClubAndGroupType(club, groupType);
+    }
 }

--- a/src/main/java/woohakdong/server/domain/member/Member.java
+++ b/src/main/java/woohakdong/server/domain/member/Member.java
@@ -96,4 +96,8 @@ public class Member extends BaseEntity {
         this.memberEmail = memberEmail;
         this.memberPassword = memberPassword;
     }
+
+    public boolean isAdmin() {
+        return this.memberRole.equals("ADMIN_ROLE");
+    }
 }

--- a/src/test/java/woohakdong/server/api/service/SecurityContextSetUp.java
+++ b/src/test/java/woohakdong/server/api/service/SecurityContextSetUp.java
@@ -1,0 +1,30 @@
+package woohakdong.server.api.service;
+
+import static woohakdong.server.config.TestConstants.TEST_PROVIDE_ID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import woohakdong.server.config.WithMockCustomUser;
+import woohakdong.server.domain.member.Member;
+import woohakdong.server.domain.member.MemberRepository;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+@WithMockCustomUser
+public abstract class SecurityContextSetUp {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    public Member createExampleMember() {
+        Member member = Member.builder()
+                .memberProvideId(TEST_PROVIDE_ID)
+                .memberName("john doe")
+                .memberEmail("johnDoe@example.com")
+                .build();
+        return memberRepository.save(member);
+    }
+}

--- a/src/test/java/woohakdong/server/api/service/auth/AuthServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/auth/AuthServiceTest.java
@@ -4,20 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static woohakdong.server.common.exception.CustomErrorInfo.INVALID_SCHOOL_DOMAIN;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+import woohakdong.server.api.service.SecurityContextSetUp;
 import woohakdong.server.common.exception.CustomException;
 import woohakdong.server.domain.school.School;
 import woohakdong.server.domain.school.SchoolRepository;
 
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-class AuthServiceTest {
+class AuthServiceTest extends SecurityContextSetUp {
 
     @Autowired
     private AuthService authService;
@@ -25,28 +21,32 @@ class AuthServiceTest {
     @Autowired
     private SchoolRepository schoolRepository;
 
+    @BeforeEach
+    void setUp() {
+        school = createSchool("ajou.ac.kr");
+    }
+
+    private School school;
+
     @DisplayName("학교 도메인인 구글 이메일로만 로그인 할 수 있다.")
     @Test
     void schoolDomainValidation() {
         // given
-        createSchool();
         String email = "uiyeop@ajou.ac.kr";
 
         //when
         School school = authService.checkSchoolDomain(email);
 
         //then
-        assertThat(school).isNotNull();
-        assertThat(school.getSchoolDomain()).isEqualTo("ajou.ac.kr");
-
-
+        assertThat(school).isNotNull()
+                        .extracting("schoolDomain")
+                        .isEqualTo("ajou.ac.kr");
     }
 
     @DisplayName("학교 도메인이 아닌 구글 이메일로는 로그인 할 수 없다.")
     @Test
     void schoolDomainInValidation() {
         // given
-        createSchool();
         String email = "uiyeop@gmail.com";
 
         //when & then
@@ -55,10 +55,10 @@ class AuthServiceTest {
                 .hasMessage(INVALID_SCHOOL_DOMAIN.getMessage());
     }
 
-    private School createSchool() {
+    private School createSchool(String domain) {
         School school = School.builder()
                 .schoolName("아주대학교")
-                .schoolDomain("ajou.ac.kr")
+                .schoolDomain(domain)
                 .build();
         return schoolRepository.save(school);
     }

--- a/src/test/java/woohakdong/server/api/service/bank/MockBankServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/bank/MockBankServiceTest.java
@@ -9,11 +9,9 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.api.controller.club.dto.ClubAccountValidateRequest;
 import woohakdong.server.api.controller.club.dto.ClubAccountValidateResponse;
+import woohakdong.server.api.service.SecurityContextSetUp;
 import woohakdong.server.common.exception.CustomException;
 import woohakdong.server.domain.admin.adminAccount.AdminAccount;
 import woohakdong.server.domain.admin.adminAccount.AdminAccountRepository;
@@ -26,10 +24,8 @@ import woohakdong.server.domain.clubAccount.ClubAccountRepository;
 import woohakdong.server.domain.member.Member;
 import woohakdong.server.domain.member.MemberRepository;
 
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-class MockBankServiceTest {
+
+class MockBankServiceTest extends SecurityContextSetUp {
 
     @Autowired
     private MockBankService mockBankService;

--- a/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_EXPIRED;
 import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_NAME_DUPLICATION;
 import static woohakdong.server.common.exception.CustomErrorInfo.CLUB_NOT_FOUND;
+import static woohakdong.server.config.TestConstants.TEST_PROVIDE_ID;
 import static woohakdong.server.domain.clubmember.ClubMemberRole.OFFICER;
 import static woohakdong.server.domain.clubmember.ClubMemberRole.PRESIDENT;
 import static woohakdong.server.domain.group.GroupType.CLUB_PAYMENT;
@@ -14,17 +15,10 @@ import static woohakdong.server.domain.member.MemberGender.MAN;
 
 import java.time.LocalDate;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.api.controller.club.dto.ClubAccountRegisterRequest;
 import woohakdong.server.api.controller.club.dto.ClubAccountResponse;
 import woohakdong.server.api.controller.club.dto.ClubCreateRequest;
@@ -34,8 +28,8 @@ import woohakdong.server.api.controller.club.dto.ClubInfoResponse;
 import woohakdong.server.api.controller.club.dto.ClubSummaryResponse;
 import woohakdong.server.api.controller.club.dto.ClubUpdateRequest;
 import woohakdong.server.api.controller.group.dto.GroupInfoResponse;
+import woohakdong.server.api.service.SecurityContextSetUp;
 import woohakdong.server.common.exception.CustomException;
-import woohakdong.server.common.security.jwt.CustomUserDetails;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
 import woohakdong.server.domain.clubAccount.ClubAccount;
@@ -52,10 +46,7 @@ import woohakdong.server.domain.member.MemberRepository;
 import woohakdong.server.domain.school.School;
 import woohakdong.server.domain.school.SchoolRepository;
 
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-class ClubServiceTest {
+class ClubServiceTest extends SecurityContextSetUp {
 
     @Autowired
     private ClubService clubService;
@@ -80,8 +71,7 @@ class ClubServiceTest {
 
     @BeforeEach
     void setUp() {
-        String provideId = setUpSecurityContextHolder("testProvideId");
-        member = createMember(provideId, "박상준", "sangjun@ajou.ac.kr");
+        member = createMember(TEST_PROVIDE_ID, "박상준", "sangjun@ajou.ac.kr");
         school = createSchool();
     }
 
@@ -421,12 +411,6 @@ class ClubServiceTest {
         return clubHistory;
     }
 
-    private @NotNull String setUpSecurityContextHolder(String provideId) {
-        CustomUserDetails userDetails = new CustomUserDetails(provideId, "USER_ROLE");
-        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(auth);
-        return provideId;
-    }
 
     private Member createMember(String provideId, String name, String email) {
         Member member = Member.builder()

--- a/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
@@ -316,7 +316,7 @@ class ClubServiceTest extends SecurityContextSetUp {
         assertThat(groups)
                 .extracting("groupType", "groupName", "groupAmount")
                 .contains(
-                        tuple(CLUB_PAYMENT, "두리안 동아리의 우학동 서비스 사용료 결제", 31500)
+                        tuple(CLUB_PAYMENT, "두리안의 우학동 서비스 사용료 결제".substring(0, 15), 31500)
                 );
     }
 

--- a/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
@@ -224,7 +224,7 @@ class ClubServiceTest extends SecurityContextSetUp {
         // Then
         assertThat(responses).hasSize(2)
                 .extracting("clubName", "clubEnglishName")
-                .containsExactlyInAnyOrder(
+                .containsExactly(
                         tuple("두리안", "Durian"),
                         tuple("우학동", "WooHakDong")
                 );

--- a/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
@@ -30,6 +30,7 @@ import woohakdong.server.api.controller.club.dto.ClubUpdateRequest;
 import woohakdong.server.api.controller.group.dto.GroupInfoResponse;
 import woohakdong.server.api.service.SecurityContextSetUp;
 import woohakdong.server.common.exception.CustomException;
+import woohakdong.server.common.util.date.DateUtil;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
 import woohakdong.server.domain.clubAccount.ClubAccount;
@@ -68,6 +69,9 @@ class ClubServiceTest extends SecurityContextSetUp {
 
     @Autowired
     private ClubMemberRepository clubMemberRepository;
+
+    @Autowired
+    private DateUtil dateUtil;
 
     @BeforeEach
     void setUp() {
@@ -120,11 +124,12 @@ class ClubServiceTest extends SecurityContextSetUp {
         // Given
         Club club = createClub(school, "두리안", "Durian", LocalDate.of(2024, 11, 19));
         setClubMember(club, LocalDate.now(), PRESIDENT, member);
+        LocalDate now = LocalDate.of(2024, 11, 19);
 
         ClubAccountRegisterRequest request = createClubAccountRegisterRequest("국민은행", "1234567890");
 
         // When
-        clubService.registerClubAccount(club.getClubId(), request);
+        clubService.registerClubAccount(club.getClubId(), request, now);
 
         // Then
         ClubAccount clubAccount = clubAccountRepository.getByClub(club);
@@ -299,7 +304,7 @@ class ClubServiceTest extends SecurityContextSetUp {
         setClubMember(club, LocalDate.of(2024, 3, 1), PRESIDENT, member);
         setClubMember(club, LocalDate.of(2024, 4, 1), OFFICER, member1);
         setClubMember(club, LocalDate.of(2024, 5, 1), OFFICER, member2);
-        LocalDate now = LocalDate.of(2024, 7, 2);
+        LocalDate now = LocalDate.of(2024, 9, 2);
 
         // When
         assertThatThrownBy(() -> clubService.checkClubExpired(club.getClubId(), now))
@@ -437,16 +442,11 @@ class ClubServiceTest extends SecurityContextSetUp {
         ClubMember clubMember = ClubMember.builder()
                 .club(club)
                 .clubJoinedDate(LocalDate.now())
-                .clubMemberAssignedTerm(getAssignedTerm(date))
+                .clubMemberAssignedTerm(dateUtil.getAssignedTerm(date))
                 .clubMemberRole(clubMemberRole)
                 .member(member)
                 .build();
         return clubMemberRepository.save(clubMember);
     }
 
-    private LocalDate getAssignedTerm(LocalDate now) {
-        int year = now.getYear();
-        int semester = now.getMonthValue() <= 6 ? 1 : 7; // 1: 1학기, 7: 2학기
-        return LocalDate.of(year, semester, 1);
-    }
 }

--- a/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/club/ClubServiceTest.java
@@ -208,6 +208,28 @@ class ClubServiceTest extends SecurityContextSetUp {
                 .containsExactly("두리안", "Durian");
     }
 
+    @DisplayName("본인이 가입한 동아리 리스트를 조회할 수 있다.")
+    @Test
+    void getJoinedClubInfos() {
+        // Given
+        Club club1 = createClub(school, "두리안", "Durian", LocalDate.of(2024, 3, 1));
+        Club club2 = createClub(school, "우학동", "WooHakDong", LocalDate.of(2024, 3, 1));
+        setClubMember(club1, LocalDate.of(2024, 3, 1), PRESIDENT, member);
+        setClubMember(club1, LocalDate.of(2024, 11, 19), OFFICER, member);
+        setClubMember(club2, LocalDate.of(2024, 3, 1), PRESIDENT, member);
+
+        // When
+        List<ClubInfoResponse> responses = clubService.getJoinedClubInfos();
+
+        // Then
+        assertThat(responses).hasSize(2)
+                .extracting("clubName", "clubEnglishName")
+                .containsExactlyInAnyOrder(
+                        tuple("두리안", "Durian"),
+                        tuple("우학동", "WooHakDong")
+                );
+    }
+
     @DisplayName("동아리의 우학동 서비스 사용 분기를 리스트로 확인할 수 있다.")
     @Test
     void checkClubHistory() {

--- a/src/test/java/woohakdong/server/api/service/clubMember/ClubMemberServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/clubMember/ClubMemberServiceTest.java
@@ -3,6 +3,7 @@ package woohakdong.server.api.service.clubMember;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
+import static woohakdong.server.config.TestConstants.TEST_PROVIDE_ID;
 import static woohakdong.server.domain.clubmember.ClubMemberRole.MEMBER;
 import static woohakdong.server.domain.clubmember.ClubMemberRole.OFFICER;
 import static woohakdong.server.domain.clubmember.ClubMemberRole.PRESIDENT;
@@ -14,15 +15,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.api.controller.clubMember.dto.ClubMemberInfoResponse;
+import woohakdong.server.api.service.SecurityContextSetUp;
 import woohakdong.server.common.exception.CustomErrorInfo;
 import woohakdong.server.common.exception.CustomException;
-import woohakdong.server.common.security.jwt.CustomUserDetails;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
 import woohakdong.server.domain.clubmember.ClubMember;
@@ -34,10 +30,7 @@ import woohakdong.server.domain.school.School;
 import woohakdong.server.domain.school.SchoolRepository;
 
 
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-class ClubMemberServiceTest {
+class ClubMemberServiceTest extends SecurityContextSetUp {
 
     @Autowired
     private ClubMemberService clubMemberService;
@@ -58,7 +51,7 @@ class ClubMemberServiceTest {
     void setUp() {
         school = createSchool("ajou.ac.kr");
         club = createClub(school);
-        member = createMember(school, "testProvideId1", "박상준", "sangjun@ajou.ac.kr");
+        member = createMember(school, TEST_PROVIDE_ID, "박상준", "sangjun@ajou.ac.kr");
     }
 
     private Member member;
@@ -147,7 +140,6 @@ class ClubMemberServiceTest {
     @Test
     void getMyInfo() {
         // Given
-        Member member = setUpMemberSession("박상준");
         createClubMember(club, member, MEMBER, LocalDate.now());
 
         // When
@@ -163,7 +155,6 @@ class ClubMemberServiceTest {
     @Test
     void changeClubMemberRole() {
         // Given
-        Member member = setUpMemberSession("박상준");
         createClubMember(club, member, PRESIDENT, LocalDate.now());
 
         Member member2 = createMember(school, "testProvideId2", "김상준", "kimsang@ajou.ac.kr");
@@ -183,7 +174,6 @@ class ClubMemberServiceTest {
     @Test
     void changeClubMemberRoleWithOutPRESIDENTRole() {
         // Given
-        Member member = setUpMemberSession("박상준");
         createClubMember(club, member, VICEPRESIDENT, LocalDate.now());
 
         Member member2 = createMember(school, "testProvideId2", "김상준", "kimsang@ajou.ac.kr");
@@ -241,21 +231,4 @@ class ClubMemberServiceTest {
         return LocalDate.of(year, semester, 1);
     }
 
-    private Member setUpMemberSession(String name) {
-        String provideId = "testProvideId";
-        Member member = Member.builder()
-                .memberProvideId(provideId)
-                .memberName(name)
-                .memberEmail("john.doe@example.com")
-                .build();
-        memberRepository.save(member);
-
-        String role = "USER_ROLE";
-        CustomUserDetails customUserDetails = new CustomUserDetails(provideId, role);
-        UsernamePasswordAuthenticationToken authToken =
-                new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(authToken);
-
-        return member;
-    }
 }

--- a/src/test/java/woohakdong/server/api/service/dues/DuesServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/dues/DuesServiceTest.java
@@ -3,10 +3,7 @@ package woohakdong.server.api.service.dues;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
-import woohakdong.server.api.service.bank.MockBankService;
+import woohakdong.server.api.service.SecurityContextSetUp;
 import woohakdong.server.domain.admin.adminAccount.AccountType;
 import woohakdong.server.domain.clubAccount.ClubAccount;
 import woohakdong.server.domain.clubAccount.ClubAccountRepository;
@@ -19,18 +16,12 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-class DuesServiceTest {
+class DuesServiceTest extends SecurityContextSetUp {
     @Autowired
     private ClubAccountHistoryRepository clubAccountHistoryRepository;
 
     @Autowired
     private ClubAccountRepository clubAccountRepository;
-
-    @Autowired
-    private MockBankService mockBankService;
 
     @Test
     @DisplayName("특정 클럽의 월별 거래 내역을 조회할 수 있다")

--- a/src/test/java/woohakdong/server/api/service/member/MemberServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/member/MemberServiceTest.java
@@ -1,31 +1,23 @@
 package woohakdong.server.api.service.member;
 
-import org.junit.jupiter.api.BeforeEach;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static woohakdong.server.common.exception.CustomErrorInfo.MEMBER_NOT_FOUND;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.api.controller.member.dto.CreateMemberRequest;
 import woohakdong.server.api.controller.member.dto.MemberInfoResponse;
+import woohakdong.server.api.service.SecurityContextSetUp;
 import woohakdong.server.common.exception.CustomException;
-import woohakdong.server.common.security.jwt.CustomUserDetails;
 import woohakdong.server.domain.member.Member;
 import woohakdong.server.domain.member.MemberGender;
 import woohakdong.server.domain.member.MemberRepository;
 import woohakdong.server.domain.school.School;
 import woohakdong.server.domain.school.SchoolRepository;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static woohakdong.server.common.exception.CustomErrorInfo.*;
-
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-class MemberServiceTest {
+class MemberServiceTest extends SecurityContextSetUp {
 
     @Autowired
     private MemberRepository memberRepository;
@@ -35,17 +27,6 @@ class MemberServiceTest {
 
     @Autowired
     private SchoolRepository schoolRepository;
-
-    @BeforeEach
-    void setUp() {
-        // SecurityContext에 CustomUserDetails 설정
-        String provideId = "testProvideId";
-        String role = "USER_ROLE";
-        CustomUserDetails customUserDetails = new CustomUserDetails(provideId, role);
-        UsernamePasswordAuthenticationToken authToken =
-                new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(authToken);
-    }
 
     @DisplayName("회원가입된 member를 업데이트 할 수 있다.")
     @Test

--- a/src/test/java/woohakdong/server/api/service/order/OrderServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/order/OrderServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static woohakdong.server.config.TestConstants.TEST_PROVIDE_ID;
 import static woohakdong.server.domain.group.GroupType.JOIN;
 import static woohakdong.server.domain.member.MemberGender.MAN;
 import static woohakdong.server.domain.order.OrderStatus.COMPLETE;
@@ -18,24 +19,17 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.api.controller.group.dto.CreateOrderRequest;
 import woohakdong.server.api.controller.group.dto.OrderIdResponse;
 import woohakdong.server.api.controller.group.dto.PaymentCompleteReqeust;
 import woohakdong.server.api.controller.group.dto.PortOneWebhookRequest;
+import woohakdong.server.api.service.SecurityContextSetUp;
 import woohakdong.server.api.service.bank.MockBankService;
-import woohakdong.server.common.security.jwt.CustomUserDetails;
 import woohakdong.server.domain.admin.adminAccount.AdminAccount;
 import woohakdong.server.domain.admin.adminAccount.AdminAccountRepository;
 import woohakdong.server.domain.club.Club;
@@ -51,10 +45,7 @@ import woohakdong.server.domain.order.OrderRepository;
 import woohakdong.server.domain.school.School;
 import woohakdong.server.domain.school.SchoolRepository;
 
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-class OrderServiceTest {
+class OrderServiceTest extends SecurityContextSetUp {
 
     @Autowired
     private OrderService orderService;
@@ -88,8 +79,7 @@ class OrderServiceTest {
 
     @BeforeEach
     void setUp() {
-        String provideId = setUpSecurityContextHolder("testProvideId");
-        member = createMember(provideId, "박상준", "sangjun@ajou.ac.kr");
+        member = createMember(TEST_PROVIDE_ID, "박상준", "sangjun@ajou.ac.kr");
         school = createSchool();
         club = createClub(school);
         group = createGroup(club, 10000, JOIN);
@@ -192,13 +182,6 @@ class OrderServiceTest {
         assertThat(order)
                 .extracting("orderStatus", "orderMerchantUid", "orderAmount")
                 .containsExactly(COMPLETE, "m-12315", 10000);
-    }
-
-    private static @NotNull String setUpSecurityContextHolder(String provideId) {
-        CustomUserDetails userDetails = new CustomUserDetails(provideId, "USER_ROLE");
-        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(auth);
-        return provideId;
     }
 
     private Member createMember(String provideId, String name, String email) {

--- a/src/test/java/woohakdong/server/api/service/order/OrderServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/order/OrderServiceTest.java
@@ -119,7 +119,7 @@ class OrderServiceTest {
 
     @DisplayName("동아리 가입 요청을 진행하면, 주문이 완료 상태로 변경된다.")
     @Test
-    void confirmJoinOrder() throws IamportResponseException, IOException {
+    void confirmOrderPayment() throws IamportResponseException, IOException {
         // Given
         Order order = createOrder(group, member, "m-12315");
 
@@ -128,7 +128,7 @@ class OrderServiceTest {
         mockingIamportResponse();
 
         // When
-        orderService.confirmJoinOrder(group.getGroupId(), confirmRequest, LocalDate.now());
+        orderService.confirmOrderPayment(group.getGroupId(), confirmRequest, LocalDate.now());
 
         // Then
         assertThat(order)
@@ -138,7 +138,7 @@ class OrderServiceTest {
 
     @DisplayName("동아리 가입 요청 완료시에, 주문에 해당하는 결제가 생성된다.")
     @Test
-    void confirmJoinOrderAndAddPayment() throws IamportResponseException, IOException {
+    void confirmOrderPaymentAndAddPayment() throws IamportResponseException, IOException {
         // Given
         Order order = createOrder(group, member, "m-12315");
 
@@ -148,7 +148,7 @@ class OrderServiceTest {
         mockingIamportResponse();
 
         // When
-        orderService.confirmJoinOrder(group.getGroupId(), confirmRequest, LocalDate.now());
+        orderService.confirmOrderPayment(group.getGroupId(), confirmRequest, LocalDate.now());
 
         // Then
         assertThat(order.getPayment()).isNotNull()
@@ -158,7 +158,7 @@ class OrderServiceTest {
 
     @DisplayName("동아리 가입 요청을 완료하면, 동아리 멤버로 추가된다.")
     @Test
-    void confirmJoinOrderAndAddClubMember() throws IamportResponseException, IOException {
+    void confirmOrderPaymentAndAddClubMember() throws IamportResponseException, IOException {
         // Given
         Order order = createOrder(group, member, "m-12315");
 
@@ -168,7 +168,7 @@ class OrderServiceTest {
         mockingIamportResponse();
 
         // When
-        orderService.confirmJoinOrder(group.getGroupId(), confirmRequest, LocalDate.now());
+        orderService.confirmOrderPayment(group.getGroupId(), confirmRequest, LocalDate.now());
 
         // Then
         assertThat(clubMemberRepository.existsByClubAndMember(club, member)).isTrue();

--- a/src/test/java/woohakdong/server/api/service/schedule/ScheduleServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/schedule/ScheduleServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static woohakdong.server.common.exception.CustomErrorInfo.SCHEDULE_NOT_FOUND;
+import static woohakdong.server.config.TestConstants.TEST_PROVIDE_ID;
 import static woohakdong.server.domain.clubmember.ClubMemberRole.OFFICER;
 import static woohakdong.server.domain.member.MemberGender.MAN;
 
@@ -15,18 +16,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.api.controller.schedule.dto.ScheduleCreateRequest;
 import woohakdong.server.api.controller.schedule.dto.ScheduleIdResponse;
 import woohakdong.server.api.controller.schedule.dto.ScheduleInfoResponse;
 import woohakdong.server.api.controller.schedule.dto.ScheduleUpdateRequest;
+import woohakdong.server.api.service.SecurityContextSetUp;
 import woohakdong.server.common.exception.CustomException;
-import woohakdong.server.common.security.jwt.CustomUserDetails;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
 import woohakdong.server.domain.clubmember.ClubMember;
@@ -36,13 +31,7 @@ import woohakdong.server.domain.member.MemberRepository;
 import woohakdong.server.domain.schedule.Schedule;
 import woohakdong.server.domain.schedule.ScheduleRepository;
 
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-class ScheduleServiceTest {
-
-    @Autowired
-    private MemberRepository memberRepository;
+class ScheduleServiceTest extends SecurityContextSetUp {
 
     @Autowired
     private ClubRepository clubRepository;
@@ -56,13 +45,12 @@ class ScheduleServiceTest {
     @Autowired
     private ScheduleRepository scheduleRepository;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     @BeforeEach
     void setUp() {
-        String provideId = "testProvideId";
-        CustomUserDetails userDetails = new CustomUserDetails(provideId, "USER_ROLE");
-        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(auth);
-        member = createMember(provideId, "박상준");
+        member = createMember(TEST_PROVIDE_ID, "박상준");
         club = createClub("두잇");
         clubMember = createClubMember(member, club);
     }

--- a/src/test/java/woohakdong/server/api/service/util/UtilServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/util/UtilServiceTest.java
@@ -9,43 +9,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.api.controller.util.dto.S3PresignedUrlResponse;
+import woohakdong.server.api.service.SecurityContextSetUp;
 import woohakdong.server.common.exception.CustomException;
-import woohakdong.server.common.security.jwt.CustomUserDetails;
-import woohakdong.server.domain.member.Member;
-import woohakdong.server.domain.member.MemberRepository;
 
-@ActiveProfiles("test")
-@SpringBootTest
-@Transactional
-class UtilServiceTest {
+class UtilServiceTest extends SecurityContextSetUp {
 
     @Autowired
     private UtilService utilService;
 
-    @Autowired
-    private MemberRepository memberRepository;
-
     @BeforeEach
     void setUp() {
-        String provideId = "testProvideId";
-        String role = "USER_ROLE";
-        Member member = Member.builder()
-                .memberProvideId(provideId)
-                .memberName("John Doe")
-                .memberEmail("john.doe@example.com")
-                .build();
-        memberRepository.save(member);
-
-        CustomUserDetails customUserDetails = new CustomUserDetails(provideId, role);
-        UsernamePasswordAuthenticationToken authToken =
-                new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(authToken);
+        createExampleMember();
     }
 
     @DisplayName("ImageCount 개수만큼 Presigned URL를 생성한다.")

--- a/src/test/java/woohakdong/server/config/TestConstants.java
+++ b/src/test/java/woohakdong/server/config/TestConstants.java
@@ -1,0 +1,5 @@
+package woohakdong.server.config;
+
+public class TestConstants {
+    public final static String TEST_PROVIDE_ID = "testProvideId";
+}

--- a/src/test/java/woohakdong/server/config/WithMockCustomUser.java
+++ b/src/test/java/woohakdong/server/config/WithMockCustomUser.java
@@ -1,0 +1,14 @@
+package woohakdong.server.config;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+
+    String role() default "ROLE_USER";
+
+    String provideId() default "testProvideId";
+}

--- a/src/test/java/woohakdong/server/config/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/woohakdong/server/config/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,20 @@
+package woohakdong.server.config;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import woohakdong.server.common.security.jwt.CustomUserDetails;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser mockUser) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        CustomUserDetails principal = new CustomUserDetails(mockUser.provideId(), mockUser.role());
+        Authentication auth = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        context.setAuthentication(auth);
+        return context;
+    }
+}

--- a/src/test/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryTest.java
+++ b/src/test/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import woohakdong.server.common.exception.CustomErrorInfo;
 import woohakdong.server.common.exception.CustomException;
+import woohakdong.server.common.util.date.DateUtil;
 import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
 import woohakdong.server.domain.member.Member;
@@ -41,6 +42,9 @@ class ClubMemberRepositoryTest {
 
     @Autowired
     private SchoolRepository schoolRepository;
+
+    @Autowired
+    private DateUtil dateUtil;
 
     @BeforeEach
     void setUp() {
@@ -99,14 +103,16 @@ class ClubMemberRepositoryTest {
         Member member2 = createMember(school, "testProvideId2", "이준상", "eejun@ajou.ac.kr");
         Member member3 = createMember(school, "testProvideId3", "최염수", "yeomsu@ajou.ac.kr");
         Member member4 = createMember(school, "testProvideId4", "옥수수", "corn@ajou.ac.kr");
+        Member member5 = createMember(school, "testProvideId5", "박상준", "sangjunpark@ajou.ac.kr");
 
         createClubMember(club, member1, PRESIDENT, LocalDate.of(2024, 4, 1));
         createClubMember(club, member2, OFFICER, LocalDate.of(2024, 7, 1));
-        createClubMember(club, member3, MEMBER, LocalDate.of(2024, 11, 19));
+        createClubMember(club, member3, MEMBER, LocalDate.of(2024, 9, 1));
         createClubMember(club, member4, MEMBER, LocalDate.of(2024, 12, 31));
+        createClubMember(club, member5, MEMBER, LocalDate.of(2025, 1, 1));
 
         // When
-        LocalDate assignedTerm = getAssignedTerm(LocalDate.of(2024, 11, 19));
+        LocalDate assignedTerm = dateUtil.getAssignedTerm(LocalDate.of(2024, 11, 19));
         Integer count = clubMemberRepository.countByClubAndAssignedTerm(club, assignedTerm);
 
         // Then
@@ -146,18 +152,11 @@ class ClubMemberRepositoryTest {
 
     private ClubMember createClubMember(Club club, Member member, ClubMemberRole memberRole, LocalDate assignedTerm) {
         ClubMember clubMember = ClubMember.builder()
-                .clubMemberAssignedTerm(getAssignedTerm(assignedTerm))
+                .clubMemberAssignedTerm(dateUtil.getAssignedTerm(assignedTerm))
                 .club(club)
                 .member(member)
                 .clubMemberRole(memberRole)
                 .build();
         return clubMemberRepository.save(clubMember);
     }
-
-    private LocalDate getAssignedTerm(LocalDate date) {
-        int year = date.getYear();
-        int semester = date.getMonthValue() <= 6 ? 1 : 7; // 1: 1학기, 7: 2학기
-        return LocalDate.of(year, semester, 1);
-    }
-
 }

--- a/src/test/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryTest.java
+++ b/src/test/java/woohakdong/server/domain/clubmember/ClubMemberRepositoryTest.java
@@ -90,7 +90,8 @@ class ClubMemberRepositoryTest {
     @Test
     void getByClubAndMember() {
         // When & Then
-        assertThatThrownBy(() -> clubMemberRepository.getByClubAndMember(null, member))
+        assertThatThrownBy(
+                () -> clubMemberRepository.getByClubAndMemberAndAssignedTerm(null, member, LocalDate.of(2024, 11, 19)))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(CustomErrorInfo.CLUB_MEMBER_NOT_FOUND.getMessage());
     }


### PR DESCRIPTION
### 기능 설명
- 동아리 서비스 사용료 후불 결제
- 그룹 관련 컨트롤러 엔드포인트 일부 수정

### 작성 상세 내용
- 동아리 서비스 사용료 관련 정보 불러오는 API 개발
- 동아리 서비스 사용료 결제 시, 6개월 연장 로직 추가
- `/v1/groups/{groupId}/joins`에서 `/v1/groups/{groupId}/orders`로 변경
- `/v1/groups/{groupId}/joins/confirms`에서 `/v1/groups/{groupId}/orders/confirm`으로 변경

### 관련 지라 티켓 번호
[WHD-210]


[WHD-210]: https://8901dev.atlassian.net/browse/WHD-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ