### PR TITLE
[WHD-214] Feat: Pass on the presidency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,8 @@ jacocoTestReport {
                     fileTree(dir: it, excludes: [
                             '**/*Application*',
                             '**/*dto*',
-                            '**/*common*'
+                            '**/*common*',
+                            '**/*Controller*',
                     ])
                 })
         )

--- a/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberController.java
+++ b/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberController.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -45,5 +46,11 @@ public class ClubMemberController implements ClubMemberControllerDocs {
                            @PathVariable Long clubMemberId,
                            @RequestParam ClubMemberRole clubMemberRole) {
         clubMemberService.changeClubMemberRole(clubId, clubMemberId, clubMemberRole, LocalDate.now());
+    }
+
+    @PostMapping("/{clubId}/members/{clubMemberId}/presidency")
+    public void passOnThePresidency(@PathVariable Long clubId,
+                                    @PathVariable Long clubMemberId) {
+        clubMemberService.passOnThePresidency(clubId, clubMemberId, LocalDate.now());
     }
 }

--- a/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberControllerDocs.java
+++ b/src/main/java/woohakdong/server/api/controller/clubMember/ClubMemberControllerDocs.java
@@ -33,4 +33,9 @@ public interface ClubMemberControllerDocs {
     @Operation(summary = "동아리 멤버 상세 정보 불러오기", description = "동아리 clubMemberId로 상세 정보를 불러온다.")
     @ApiResponse(responseCode = "200", description = "동아리 멤버 상세 정보 불러오기 성공", useReturnTypeSchema = true)
     public ClubMemberInfoResponse getClubMemberInfo(Long clubId, Long clubMemberId);
+
+    @SecurityRequirement(name = "accessToken")
+    @Operation(summary = "동아리 멤버에게 회장 권한 위임하기", description = "동아리 멤버에게 회장 권한을 위임한다.")
+    @ApiResponse(responseCode = "200", description = "동아리 멤버에게 회장 권한 위임하기 성공", useReturnTypeSchema = true)
+    public void passOnThePresidency(Long clubId, Long clubMemberId);
 }

--- a/src/main/java/woohakdong/server/api/service/clubMember/ClubMemberService.java
+++ b/src/main/java/woohakdong/server/api/service/clubMember/ClubMemberService.java
@@ -18,6 +18,8 @@ import woohakdong.server.domain.club.Club;
 import woohakdong.server.domain.club.ClubRepository;
 import woohakdong.server.domain.clubAccount.ClubAccount;
 import woohakdong.server.domain.clubAccount.ClubAccountRepository;
+import woohakdong.server.domain.clubAccountHistory.ClubAccountHistory;
+import woohakdong.server.domain.clubAccountHistory.ClubAccountHistoryRepository;
 import woohakdong.server.domain.clubmember.ClubMember;
 import woohakdong.server.domain.clubmember.ClubMemberRepository;
 import woohakdong.server.domain.clubmember.ClubMemberRole;
@@ -34,6 +36,7 @@ public class ClubMemberService {
     private final ClubMemberRepository clubMemberRepository;
     private final ClubRepository clubRepository;
     private final ClubAccountRepository clubAccountRepository;
+    private final ClubAccountHistoryRepository clubAccountHistoryRepository;
 
     public List<ClubMemberInfoResponse> getMembers(Long clubId, LocalDate date) {
         Club club = clubRepository.getById(clubId);
@@ -101,6 +104,7 @@ public class ClubMemberService {
         president.changeRole(OFFICER);
 
         ClubAccount clubAccount = clubAccountRepository.getByClub(club);
+        clubAccountHistoryRepository.deleteAllByClubAccount(clubAccount);
         clubAccountRepository.delete(clubAccount);
     }
 }

--- a/src/main/java/woohakdong/server/domain/clubAccount/ClubAccountRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubAccount/ClubAccountRepository.java
@@ -8,4 +8,6 @@ public interface ClubAccountRepository {
     ClubAccount getByClub(Club club);
 
     ClubAccount save(ClubAccount clubAccount);
+
+    void delete(ClubAccount clubAccount);
 }

--- a/src/main/java/woohakdong/server/domain/clubAccount/ClubAccountRepositoryImpl.java
+++ b/src/main/java/woohakdong/server/domain/clubAccount/ClubAccountRepositoryImpl.java
@@ -30,5 +30,9 @@ public class ClubAccountRepositoryImpl implements ClubAccountRepository {
         return clubAccountJpaRepository.save(clubAccount);
     }
 
+    @Override
+    public void delete(ClubAccount clubAccount) {
+        clubAccountJpaRepository.delete(clubAccount);
+    }
 
 }

--- a/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryJpaRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryJpaRepository.java
@@ -20,4 +20,6 @@ public interface ClubAccountHistoryJpaRepository extends JpaRepository<ClubAccou
                                                      @Param("month") int month);
 
     List<ClubAccountHistory> findAllByClubAccountClubOrderByClubAccountHistoryTranDateDesc(Club club);
+
+    void deleteAllByClubAccount(ClubAccount clubAccount);
 }

--- a/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryRepository.java
+++ b/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryRepository.java
@@ -13,4 +13,6 @@ public interface ClubAccountHistoryRepository {
     List<ClubAccountHistory> findMonthlyTransactions(ClubAccount clubAccount, int year, int month);
 
     List<ClubAccountHistory> findAllByClubAccountClub(Club club);
+
+    void deleteAllByClubAccount(ClubAccount clubAccount);
 }

--- a/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryRepositoryImpl.java
+++ b/src/main/java/woohakdong/server/domain/clubAccountHistory/ClubAccountHistoryRepositoryImpl.java
@@ -32,4 +32,9 @@ public class ClubAccountHistoryRepositoryImpl implements ClubAccountHistoryRepos
     public List<ClubAccountHistory> findAllByClubAccountClub(Club club) {
         return clubAccountHistoryJpaRepository.findAllByClubAccountClubOrderByClubAccountHistoryTranDateDesc(club);
     }
+
+    @Override
+    public void deleteAllByClubAccount(ClubAccount clubAccount) {
+        clubAccountHistoryJpaRepository.deleteAllByClubAccount(clubAccount);
+    }
 }

--- a/src/test/java/woohakdong/server/api/service/clubMember/ClubMemberServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/clubMember/ClubMemberServiceTest.java
@@ -210,11 +210,11 @@ class ClubMemberServiceTest extends SecurityContextSetUp {
         LocalDate date = LocalDate.of(2024, 11, 19);
         Member member2 = createMember(school, "testProvideId3", "준상박", "junsang@ajou.ac.kr");
         createClubMember(club, member, PRESIDENT, date);
-        createClubMember(club, member2, VICEPRESIDENT, date);
+        ClubMember clubMember = createClubMember(club, member2, VICEPRESIDENT, date);
         createClubAccount(club);
 
         // When
-        clubMemberService.passOnThePresidency(club.getClubId(), member2.getMemberId(), date);
+        clubMemberService.passOnThePresidency(club.getClubId(), clubMember.getClubMemberId(), date);
 
         // Then
         List<ClubMember> clubMemberList = clubMemberRepository.getAll();
@@ -233,11 +233,11 @@ class ClubMemberServiceTest extends SecurityContextSetUp {
         LocalDate date = LocalDate.of(2024, 11, 19);
         Member member2 = createMember(school, "testProvideId3", "준상박", "junsang@ajou.ac.kr");
         createClubMember(club, member, PRESIDENT, date);
-        createClubMember(club, member2, VICEPRESIDENT, date);
-        ClubAccount clubAccount = createClubAccount(club);
+        ClubMember clubMember = createClubMember(club, member2, VICEPRESIDENT, date);
+        createClubAccount(club);
 
         // When
-        clubMemberService.passOnThePresidency(club.getClubId(), member2.getMemberId(), date);
+        clubMemberService.passOnThePresidency(club.getClubId(), clubMember.getClubMemberId(), date);
 
         // Then
         assertThatThrownBy(


### PR DESCRIPTION
### 기능 설명
동아리 회장 권한 위임

### 작성 상세 내용
- 동아리 회장 권한을 위임할 수 있다.
- 기존의 동아리 회장은 임원진 역할로 변경된다.
- 기존의 동아리 계좌는 삭제된다. ( 비즈니스 상 필수 )
- 기존의 동아리 계좌와 연결된 계좌 내역들은 모두 삭제된다. ( 비즈니스 상 필수 )

### 관련 지라 티켓 번호
[WHD-214]


[WHD-214]: https://8901dev.atlassian.net/browse/WHD-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ