### PR TITLE
[WHD-290] Fix: Order update with pessimistic lock

### DIFF
--- a/src/main/java/woohakdong/server/api/service/order/OrderService.java
+++ b/src/main/java/woohakdong/server/api/service/order/OrderService.java
@@ -78,7 +78,7 @@ public class OrderService {
     @Transactional
     public void confirmOrderPayment(Long groupId, PaymentCompleteReqeust request, LocalDate date) {
         Member member = securityUtil.getMember();
-        Order order = orderRepository.getById(request.orderId());
+        Order order = orderRepository.getByIdWithLock(request.orderId());
 
         if (order.isOrderComplete()) {
             return;

--- a/src/main/java/woohakdong/server/domain/order/OrderJpaRepository.java
+++ b/src/main/java/woohakdong/server/domain/order/OrderJpaRepository.java
@@ -1,10 +1,17 @@
 package woohakdong.server.domain.order;
 
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
     boolean existsByOrderMerchantUid(String orderMerchantUid);
 
     Optional<Order> findByOrderMerchantUid(String orderMerchantUid);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM Order o WHERE o.orderId = :orderId")
+    Optional<Order> findByOrderIdWithLock(Long orderId);
 }

--- a/src/main/java/woohakdong/server/domain/order/OrderRepository.java
+++ b/src/main/java/woohakdong/server/domain/order/OrderRepository.java
@@ -3,7 +3,7 @@ package woohakdong.server.domain.order;
 public interface OrderRepository {
     Order save(Order order);
 
-    Order getById(Long orderId);
+    Order getByIdWithLock(Long orderId);
 
     boolean existsByOrderMerchantUid(String orderMerchantUid);
 

--- a/src/main/java/woohakdong/server/domain/order/OrderRepositoryImpl.java
+++ b/src/main/java/woohakdong/server/domain/order/OrderRepositoryImpl.java
@@ -18,8 +18,8 @@ public class OrderRepositoryImpl implements OrderRepository{
     }
 
     @Override
-    public Order getById(Long orderId) {
-        return orderJpaRepository.findById(orderId)
+    public Order getByIdWithLock(Long orderId) {
+        return orderJpaRepository.findByOrderIdWithLock(orderId)
                 .orElseThrow(() -> new CustomException(ORDER_NOT_FOUND));
     }
 

--- a/src/test/java/woohakdong/server/api/service/order/OrderServiceTest.java
+++ b/src/test/java/woohakdong/server/api/service/order/OrderServiceTest.java
@@ -22,7 +22,6 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import woohakdong.server.api.controller.group.dto.CreateOrderRequest;
@@ -31,7 +30,6 @@ import woohakdong.server.api.controller.group.dto.PaymentCompleteReqeust;
 import woohakdong.server.api.controller.group.dto.PortOneWebhookRequest;
 import woohakdong.server.SecurityContextSetup;
 import woohakdong.server.api.service.bank.MockBankService;
-import woohakdong.server.config.WithoutRedisConfig;
 import woohakdong.server.domain.admin.adminAccount.AdminAccount;
 import woohakdong.server.domain.admin.adminAccount.AdminAccountRepository;
 import woohakdong.server.domain.club.Club;
@@ -103,7 +101,7 @@ class OrderServiceTest extends SecurityContextSetup {
         OrderIdResponse response = orderService.registerOrder(group.getGroupId(), request);
 
         // Then
-        Order order = orderRepository.getById(response.orderId());
+        Order order = orderRepository.getByIdWithLock(response.orderId());
         assertThat(order)
                 .extracting("orderMerchantUid", "orderAmount", "orderStatus", "member.memberId")
                 .containsExactly("m-12315", 10000, INIT, member.getMemberId());


### PR DESCRIPTION
### 기능 설명
주문 상태 변경 시, 비관적 락 이용하도록 변경

### 작성 상세 내용
- 클라이언트 측 결제 완료와 포트원 측 Webhook이 동시에 접근하여 Race Condition이 발생
- 이를 비관적 락을 통해 먼저 접근한 쓰레드가 상태를 변경할 때까지 대기하도록 변경

### 관련 지라 티켓 번호
[WHD-290]

### 참고 자료
